### PR TITLE
Fixed language switching on admin pages. 

### DIFF
--- a/src/app/admin/documents/page.tsx
+++ b/src/app/admin/documents/page.tsx
@@ -14,7 +14,8 @@ import useCreateTable from "@/widgets/useCreateTable";
 import { useTranslation } from "react-i18next";
 
 
-export default function Events() {
+export default function Documents() {
+	// TODO: Fix this page lmao
 	const { t } = useTranslation();
 	const { data, error, isPending } = useQuery({
 		...getAllEventsOptions(),

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -4,31 +4,31 @@ import initTranslations, { type Locale, type Namespace } from "../i18n";
 import TranslationsProvider from "@/components/TranslationsProvider";
 import LoginWall from "@/components/LoginWall";
 
-const locale = "sv" satisfies Locale;
-const i18nNamespaces = ["admin"] satisfies Namespace[];
+// const locale = "sv" satisfies Locale;
+// const i18nNamespaces = ["admin"] satisfies Namespace[];
 
 export default async function AdminLayout({
 	children,
 }: {
 	children: React.ReactNode;
 }) {
-	const { resources } = await initTranslations(locale, i18nNamespaces);
+	// const { resources } = await initTranslations(locale, i18nNamespaces);
 
 	return (
-		<TranslationsProvider
-			namespaces={i18nNamespaces}
-			locale={locale}
-			resources={resources}
-		>
-			<LoginWall>
-				<SidebarProvider>
-					<AdminSidebar />
-					<main>
-						<SidebarTrigger />
-						{children}
-					</main>
-				</SidebarProvider>
-			</LoginWall>
-		</TranslationsProvider>
+		// <TranslationsProvider
+		// 	namespaces={i18nNamespaces}
+		// 	locale={locale}
+		// 	resources={resources}
+		// >
+		<LoginWall>
+			<SidebarProvider>
+				<AdminSidebar />
+				<main>
+					<SidebarTrigger />
+					{children}
+				</main>
+			</SidebarProvider>
+		</LoginWall>
+		// </TranslationsProvider>
 	);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import { NavBar } from "../components/NavBar";
 import Footer from "@/components/Footer";
 
 const locale = "sv" satisfies Locale;
-const i18nNamespaces = ["main", "namnden"] satisfies Namespace[];
+const i18nNamespaces = ["main", "namnden", "admin"] satisfies Namespace[];
 
 export default async function RootLayout({
 	children,


### PR DESCRIPTION
I'm not certain how the localization system works but this might make the system more clunky if the admin lang files are loaded even when on the non admin pages. I didn't find any other way of getting the language switcher to switch the language of admin pages however.