### PR TITLE
Allocate more ram for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
 			"extensions": [
 				"biomejs.biome",
 				"ms-vscode.vscode-typescript-next",
-				"bradlc.vscode-tailwindcss" // Tailwind CSS IntelliSense extension
+				"bradlc.vscode-tailwindcss", // Tailwind CSS IntelliSense extension
+				"oven.bun-vscode" // Bun extension
 			],
 			"settings": {
 				"editor.tabSize": 2,
@@ -28,6 +29,10 @@
 			}
 		}
 	},
-	"runArgs": ["--network=host", "--add-host=host.docker.internal:host-gateway"],
+	"runArgs": [
+		"--network=host",
+		"--add-host=host.docker.internal:host-gateway",
+		"--memory=7gb"
+	],
 	"postCreateCommand": "bun install"
 }


### PR DESCRIPTION
Currently, the devcontainer allocates approx. 4GB of ram for the frontend. This is not enough and because of this we get strange errors like bun abruptly exiting and _extremely_ slow compile times for nextjs. This PR attempts to fix this by allocating more ram by default for the container. Looking for feedback on the following:

- Is 7GB excessive? It seems like we usually run at 5-6GB
- Will this actually affect the amount of ram used by docker on PC:s with docker desktop?
- Will this cause problems for people with less than 8GB of ram? Do we have anyone with less ram than that?

Oh also i added the bun extension apparently