### PR TITLE
Add contact page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,6 +71,7 @@
         "react-hook-form": "^7.54.2",
         "react-hotkeys-hook": "^4.6.1",
         "react-i18next": "^15.4.1",
+        "react-obfuscate": "^3.7.0",
         "react-pdf": "^10.0.1",
         "react-resizable-panels": "^2.1.7",
         "react-select": "^5.10.1",
@@ -1124,6 +1125,8 @@
     "react-i18next": ["react-i18next@15.6.1", "", { "dependencies": { "@babel/runtime": "^7.27.6", "html-parse-stringify": "^3.0.1" }, "peerDependencies": { "i18next": ">= 23.2.3", "react": ">= 16.8.0", "typescript": "^5" }, "optionalPeers": ["typescript"] }, "sha512-uGrzSsOUUe2sDBG/+FJq2J1MM+Y4368/QW8OLEKSFvnDflHBbZhSd1u3UkW0Z06rMhZmnB/AQrhCpYfE5/5XNg=="],
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "react-obfuscate": ["react-obfuscate@3.7.0", "", { "peerDependencies": { "prop-types": ">= 15", "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-y/sd0W8VuzoH6kGXjwdFCvCRxqBeffyaxrqyfWjACY8Ejl9sGaJbRf1iJXHYkQU4Va81G2triRkgHhsfNIx5FQ=="],
 
     "react-pdf": ["react-pdf@10.0.1", "", { "dependencies": { "clsx": "^2.0.0", "dequal": "^2.0.3", "make-cancellable-promise": "^2.0.0", "make-event-props": "^2.0.0", "merge-refs": "^2.0.0", "pdfjs-dist": "5.3.31", "tiny-invariant": "^1.0.0", "warning": "^4.0.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-dblLZ5BqubeNFZwTzHkRi7Rexev2+Xb9z7sEvNYT+IOxmih1KgrByeqD4Hm0RnwR9nTWludXbiHQMe9d47DK2w=="],
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
 		"react-hook-form": "^7.54.2",
 		"react-hotkeys-hook": "^4.6.1",
 		"react-i18next": "^15.4.1",
+		"react-obfuscate": "^3.7.0",
 		"react-pdf": "^10.0.1",
 		"react-resizable-panels": "^2.1.7",
 		"react-select": "^5.10.1",

--- a/src/app/(public)/(mdx)/foretag/om/page.en.mdx
+++ b/src/app/(public)/(mdx)/foretag/om/page.en.mdx
@@ -21,7 +21,7 @@ The F-guild's Corporate Relations Committee work with the goal to provide their 
   variant="outline"
   className="text-primary p-5"
 >
-<Link href="/contact">Contact us</Link>
+<Link href="/contact#naringslivsutskottet">Contact us</Link>
 </Button>
 
 ---

--- a/src/app/(public)/(mdx)/foretag/om/page.sv.mdx
+++ b/src/app/(public)/(mdx)/foretag/om/page.sv.mdx
@@ -22,7 +22,7 @@ Vi på F-sektionens näringslivsutskott arbetar med målet att våra studenter s
   variant="outline"
   className="text-primary p-5"
 >
-  <Link href="/contact">Kontakta oss</Link>
+  <Link href="/contact#naringslivsutskottet">Kontakta oss</Link>
 </Button>
 
 ---

--- a/src/app/(public)/(mdx)/foretag/vi-erbjuder/page.en.mdx
+++ b/src/app/(public)/(mdx)/foretag/vi-erbjuder/page.en.mdx
@@ -23,7 +23,7 @@ If you are interested in cooperating with us, please use the following link:
 
 ## Proposals for collaborations
 
-Please note that more options are offered in connection with FARAD and our introductory period. For information about these opportunities as well as other offers, please see [this pdf](https://old.fsektionen.se/dokument/826). If you wish to collaborate with us, woud like further information or have your own suggestions for collaborations, please [email naringsliv@fsektionen.se](mailto:naringsliv@fsektionen.se) or use [this form](/contact).
+Please note that more options are offered in connection with FARAD and our introductory period. For information about these opportunities as well as other offers, please see [this pdf](https://old.fsektionen.se/dokument/826). If you wish to collaborate with us, woud like further information or have your own suggestions for collaborations, please [email naringsliv@fsektionen.se](mailto:naringsliv@fsektionen.se).
 
 #### Lunch lecture
 

--- a/src/app/(public)/(mdx)/foretag/vi-erbjuder/page.sv.mdx
+++ b/src/app/(public)/(mdx)/foretag/vi-erbjuder/page.sv.mdx
@@ -16,13 +16,13 @@ Ifall ni är intresserade av samarbete kan ni kontakta oss via följande länk:
   variant="outline"
   className="text-primary p-5"
 >
-  <Link href="/contact">Kontakta oss</Link>
+  <Link href="/contact#naringslivsutskottet">Kontakta oss</Link>
 </Button>
 
 ---
 ## Förslag på samarbeten
 
-Observera att fler alternativ erbjuds i samband med FARAD och vår nollning. För information om dessa tillfällen samt andra erbjudanden, var god se [denna pdf](https://old.fsektionen.se/dokument/826). Ifall ni önskar samarbeta med oss, söker ytterligare information eller har egna förslag på samarbeten ber vi er att [maila näringslivsansvarig](mailto:naringsliv@fsektionen.se) eller att ni använder [detta formulär](/contact).
+Observera att fler alternativ erbjuds i samband med FARAD och vår nollning. För information om dessa tillfällen samt andra erbjudanden, var god se [denna pdf](https://old.fsektionen.se/dokument/826). Ifall ni önskar samarbeta med oss, söker ytterligare information eller har egna förslag på samarbeten ber vi er att [maila näringslivsansvarig](mailto:naringsliv@fsektionen.se).
 
 #### Lunchföredrag
 

--- a/src/app/(public)/(mdx)/projects/page.en.mdx
+++ b/src/app/(public)/(mdx)/projects/page.en.mdx
@@ -1,10 +1,10 @@
 # Projects
 
-How fun that you're thinking about starting a project! There are so many things you can do, and it all starts with an idea you have that you want to realize but might not have the resources for. It can sometimes seem a bit complicated and intimidating with all the rules you need to keep track of, but it's actually not that hard! Here's some information on how to get started if you're interested in doing a project! In the field next to this, there are ideas for projects that haven't started yet — are you interested in leading one of them? [Then contact the vice chairperson!](/contact)
+How fun that you're thinking about starting a project! There are so many things you can do, and it all starts with an idea you have that you want to realize but might not have the resources for. It can sometimes seem a bit complicated and intimidating with all the rules you need to keep track of, but it's actually not that hard! Here's some information on how to get started if you're interested in doing a project! In the field next to this, there are ideas for projects that haven't started yet — are you interested in leading one of them? [Then contact the vice president!](/contact#vice)
 
-Our guild has lots of equipment that's underutilized, and we can also support you financially. If you only need up to 500 SEK, just apply — need more than that? Don't hesitate to [contact the board](/contact) or the [vice chairperson](/contact), they can help you get the funding you need.
+Our guild has lots of equipment that's underutilized, and we can also support you financially. If you only need up to 500 SEK, just apply — need more than that? Don't hesitate to [contact the board](/contact#board) or the [vice president](/contact#vice), they can help you get the funding you need.
 
-When applying, you should have a conversation with the vice chairperson to make sure everything is in order, and submit a completed [project plan](https://old.fsektionen.se/dokument/140). If you have more questions, just [contact the vice chairperson](/contact).
+When applying, you should have a conversation with the vice chairperson to make sure everything is in order, and submit a completed [project plan](https://old.fsektionen.se/dokument/140). If you have more questions, just [contact the vice president](/contact#vice).
 
 ### Project Ideas
 

--- a/src/app/(public)/(mdx)/projects/page.sv.mdx
+++ b/src/app/(public)/(mdx)/projects/page.sv.mdx
@@ -1,10 +1,10 @@
 # Projekt
 
-Vad kul att du funderar på att göra ett projekt! Det finns så mycket saker man kan göra och allt börjar med en idé du har som du vill genomföra men kanske inte har medel till. Det kan verka lite krångligt och avskräckande ibland med alla regler som man måste hålla koll på men det är faktiskt inte så svårt! Här finns därför lite information om hur man går tillväga om man är sugen på att projekta lite! I fältet här bredvid finns det uppslag på projekt som ännu inte har startat, är du sugen på att dra i något av dessa? [Kontakta då vice ordförande!](/contact)
+Vad kul att du funderar på att göra ett projekt! Det finns så mycket saker man kan göra och allt börjar med en idé du har som du vill genomföra men kanske inte har medel till. Det kan verka lite krångligt och avskräckande ibland med alla regler som man måste hålla koll på men det är faktiskt inte så svårt! Här finns därför lite information om hur man går tillväga om man är sugen på att projekta lite! I fältet här bredvid finns det uppslag på projekt som ännu inte har startat, är du sugen på att dra i något av dessa? [Kontakta då vice ordförande!](/contact#vice)
 
-Vår sektion har massa prylar som används för lite och vi kan även hjälpa dig ekonomiskt. Om du bara behöver upp till 500 kronor är det bara att ansöka, behöver du mer än så? Tveka inte att [kontakta styrelsen](/contact) eller [vice ordförande](contact), de kan hjälpa dig så att du får de pengar du behöver.
+Vår sektion har massa prylar som används för lite och vi kan även hjälpa dig ekonomiskt. Om du bara behöver upp till 500 kronor är det bara att ansöka, behöver du mer än så? Tveka inte att [kontakta styrelsen](/contact#board) eller [vice ordförande](/contact#vice), de kan hjälpa dig så att du får de pengar du behöver.
 
-När man ansöker ska man ha en dialog med vice ordförande så att allt är okej samt lämna in en [ifylld projektplan](https://old.fsektionen.se/dokument/140). Om man har fler frågor är det bara att [kontakta vice ordförande](/contact).
+När man ansöker ska man ha en dialog med vice ordförande så att allt är okej samt lämna in en [ifylld projektplan](https://old.fsektionen.se/dokument/140). Om man har fler frågor är det bara att [kontakta vice ordförande](/contact#vice).
 
 ### Projektidéer
 

--- a/src/app/(public)/(mdx)/tools/page.en.mdx
+++ b/src/app/(public)/(mdx)/tools/page.en.mdx
@@ -1,6 +1,6 @@
 # The Guild's tools
 
-The Facilities Committee has many different tools, which you can find in the list below. As a member of the guild you may rent these. In order to do so contact a caretaker, e.g. by sending an email to fixare@fsektionen.se. Optionally you can [contact the Head of Facilities](/contact).
+The Facilities Committee has many different tools, which you can find in the list below. As a member of the guild you may rent these. In order to do so contact a caretaker, e.g. by sending an email to fixare@fsektionen.se. Optionally you can [contact the Head of Facilities](/contact#facilities).
 
 The number shown is the total number held by the guild, it does not necessarily mean that there are that many available!
 

--- a/src/app/(public)/(mdx)/tools/page.sv.mdx
+++ b/src/app/(public)/(mdx)/tools/page.sv.mdx
@@ -1,6 +1,6 @@
 # Sektionens verktyg
 
-Prylmästeriet har en uppsjö av olika verktyg som du kan hitta i listan nedanför. Som sektionsmedlem är du välkommen att låna dessa. För detta tar du lämpligen kontakt med en fixare, exempelvis via fixare@fsektionen.se. Annars kan du [kontakta Prylmästaren](/contact).
+Prylmästeriet har en uppsjö av olika verktyg som du kan hitta i listan nedanför. Som sektionsmedlem är du välkommen att låna dessa. För detta tar du lämpligen kontakt med en fixare, exempelvis via fixare@fsektionen.se. Annars kan du [kontakta Prylmästaren](/contact#facilities).
 
 Antalet som visas är det totala antalet som sektionen innehar, det måste inte betyda att det finns så många tillgängliga! Spindelmästeriet kommer att arbeta för att skapa ett ordentligt bokningssystem.
 

--- a/src/app/(public)/car/page.tsx
+++ b/src/app/(public)/car/page.tsx
@@ -121,7 +121,7 @@ export default function Car() {
 					? "#e68a00" // TODO: Use tailwind for this somehow
 					: "#ffd699"
 				: // Use a different color for the current user's bookings
-					car.confirmed
+				car.confirmed
 					? "#66cc00"
 					: "#e6e600"; // Green for confirmed, yellow for unconfirmed
 			return {
@@ -176,7 +176,7 @@ export default function Car() {
 												onError: (error) => {
 													toast.error(
 														t("admin:car.error_add") +
-															(error?.detail ? `: ${error.detail}` : ""),
+														(error?.detail ? `: ${error.detail}` : ""),
 													);
 												},
 												onSuccess: () => {
@@ -192,7 +192,7 @@ export default function Car() {
 												onError: (error) => {
 													toast.error(
 														t("admin:car.error_delete") +
-															(error?.detail ? `: ${error.detail}` : ""),
+														(error?.detail ? `: ${error.detail}` : ""),
 													);
 												},
 												onSuccess: () => {
@@ -231,7 +231,7 @@ export default function Car() {
 												onError: (error) => {
 													toast.error(
 														t("admin:car.error_edit") +
-															(error?.detail ? `: ${error.detail}` : ""),
+														(error?.detail ? `: ${error.detail}` : ""),
 													);
 												},
 												onSuccess: () => {
@@ -348,7 +348,7 @@ export default function Car() {
 									<Trans i18nKey="main:car-booking.faq.a7">
 										<Link
 											className="text-blue-500 hover:text-blue-700 underline mr-0"
-											href="/contact"
+											href="/contact#car"
 										/>
 									</Trans>
 								</AccordionContent>

--- a/src/app/(public)/contact/ContactCard.tsx
+++ b/src/app/(public)/contact/ContactCard.tsx
@@ -1,0 +1,77 @@
+import { Card, CardContent } from "@/components/ui/card"
+import { Mail, User } from "lucide-react"
+import Obfuscate from "react-obfuscate"
+import clsx from "clsx"
+
+interface ContactCardProps {
+  title: string
+  fullName: string
+  email: string
+  imageAlt?: string
+  id?: string
+  highlight?: boolean
+}
+
+export default function ContactCard({ title, fullName, email, imageAlt, id, highlight }: ContactCardProps) {
+  return (
+    <Card
+      id={id}
+      className={clsx(
+        "w-full max-w-md hover:shadow-md transition-shadow duration-200 scroll-mt-40",
+        highlight && "animate-[flash_1.5s]"
+      )}
+      // Tailwind custom animation, see below for keyframes
+      style={{
+        ...(highlight
+          ? {
+            animation: "flash 2s",
+          }
+          : {}),
+      }}
+    >
+      <CardContent className="p-4">
+        <div className="flex items-center space-x-4">
+          {/* Image Placeholder */}
+          <div className="flex-shrink-0">
+            <div className="w-16 h-16 bg-muted rounded-full flex items-center justify-center">
+              <User className="w-8 h-8 text-muted-foreground" />
+              {imageAlt && <span className="sr-only">{imageAlt}</span>}
+            </div>
+          </div>
+
+          {/* Contact Information */}
+          <div className="flex-1 min-w-0">
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-primary uppercase tracking-wide">
+                {title}
+              </p>
+              <div className="overflow-x-auto scrollbar-thin scrollbar-thumb-muted">
+                <span className="text-lg font-semibold text-foreground whitespace-nowrap block">
+                  {fullName}
+                </span>
+              </div>
+              <div className="flex items-center space-x-1 text-sm text-muted-foreground hover:text-foreground">
+                <Mail className="w-4 h-4 flex-shrink-0" />
+                <Obfuscate
+                  email={email}
+                  style={{ textDecoration: "underline", color: "inherit", cursor: "pointer" }}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+      <style jsx global>{`
+        @keyframes flash {
+          0% { box-shadow: 0 0 0 0 #facc15; }
+          10% { box-shadow: 0 0 0 4px #facc15; }
+          20% { box-shadow: 0 0 0 8px #fde68a; }
+          40% { box-shadow: 0 0 0 8px #fde68a; }
+          60% { box-shadow: 0 0 0 4px #facc15; }
+          80% { box-shadow: 0 0 0 0 #facc15; }
+          100% { box-shadow: 0 0 0 0 transparent; }
+        }
+      `}</style>
+    </Card>
+  )
+}

--- a/src/app/(public)/contact/EmergencyCard.tsx
+++ b/src/app/(public)/contact/EmergencyCard.tsx
@@ -1,0 +1,94 @@
+
+import Obfuscate from "react-obfuscate";
+import { useTranslation } from "react-i18next";
+import { Card } from "@/components/ui/card";
+
+
+export default function EmergencyCard() {
+  const { t } = useTranslation("contact");
+  return (
+    <Card className="px-8 md:px-12 w-full bg-destructive/10 border-destructive/30 dark:bg-destructive/50 border shadow-lg">
+      <div className="text-2xl font-bold text-center text-destructive dark:text-destructive-foreground m-0 p-0">
+        {t("emergency.title")}
+      </div>
+      <div className="grid grid-cols-1 xl:grid-cols-3 whitespace-pre-wrap wrap-normal">
+        <div className="flex flex-col mt-3">
+          <p className="text-base">
+            <span className="font-bold">{t("emergency.text_ordf.self")}</span>
+            <br />
+            {t("emergency.text_ordf.name")} - Ester:{" "}
+            <Obfuscate
+              email="ordf@fsektionen.se"
+              style={{ textDecoration: "underline" }}
+            />
+            <br />
+            <Obfuscate
+              tel="+46 073-642 16 17"
+              style={{ textDecoration: "underline" }}
+            />
+          </p>
+        </div>
+        <div className="flex flex-col mt-3">
+          <p className="text-base">
+            <span className="font-bold">{t("emergency.text_foset.self")}</span>
+            <br />
+            <Obfuscate
+              email="foset@fsektionen.se"
+              style={{ textDecoration: "underline" }}
+            />
+            <br />
+            Överfös Victor:{" "}
+            <Obfuscate
+              tel="+46 076-195 02 25"
+              style={{ textDecoration: "underline" }}
+            />
+            <br />
+            Cofös Tova:{" "}
+            <Obfuscate
+              tel="+46 070-957 88 52"
+              style={{ textDecoration: "underline" }}
+            />
+          </p>
+        </div>
+        <div className="flex flex-col mt-3">
+          <p className="text-base">
+            <span className="font-bold">{t("emergency.text_car.self")}</span>
+            <br />
+            {t("emergency.text_car.name1")} - Vic:{" "}
+            <Obfuscate
+              email="bil@fsektionen.se"
+              style={{ textDecoration: "underline" }}
+            />
+            <br />
+            <Obfuscate
+              tel="+46 076-020 82 17"
+              style={{ textDecoration: "underline" }}
+            />
+            <br />
+            {t("emergency.text_car.name2")} - Alva:{" "}
+            <Obfuscate
+              email="prylm@fsektionen.se"
+              style={{ textDecoration: "underline" }}
+            />
+            <br />
+            <Obfuscate
+              tel="+46 070-794 98 92"
+              style={{ textDecoration: "underline" }}
+            />
+            <br />
+            {t("emergency.text_car.name3")} - Ester:{" "}
+            <Obfuscate
+              email="ordf@fsektionen.se"
+              style={{ textDecoration: "underline" }}
+            />
+            <br />
+            <Obfuscate
+              tel="+46 073-642 16 17"
+              style={{ textDecoration: "underline" }}
+            />
+          </p>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/app/(public)/contact/page.tsx
+++ b/src/app/(public)/contact/page.tsx
@@ -1,5 +1,219 @@
-import { redirect } from "next/navigation";
+"use client";
 
-export default function ForetagPage() {
-	redirect("https://old.fsektionen.se/kontakter");
+import TitleBanner from "@/components/TitleBanner";
+import CustomTitle from "@/components/CustomTitle";
+import mh from "@/assets/mh.jpg";
+import { useTranslation } from 'react-i18next';
+import { Card } from '@/components/ui/card';
+import EmergencyCard from './EmergencyCard';
+import ContactCard from './ContactCard';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from "react";
+
+export default function ContactPage() {
+	const { t } = useTranslation("contact");
+	const router = useRouter();
+
+	const [highlightedId, setHighlightedId] = useState<string | null>(null);
+
+	useEffect(() => {
+		const handleHashChange = () => {
+			const hash = window.location.hash.replace("#", "");
+			if (hash) {
+				setHighlightedId(hash);
+				// Remove highlight after 2s
+				setTimeout(() => setHighlightedId(null), 2000);
+			}
+		};
+		handleHashChange(); // run on mount
+		window.addEventListener("hashchange", handleHashChange);
+		return () => window.removeEventListener("hashchange", handleHashChange);
+	}, []);
+
+	return (
+		<div className="flex flex-col min-h-screen">
+			<TitleBanner
+				title={t("title")}
+				imageUrl={mh.src}
+				className="relative h-[30vh] bg-cover bg-center"
+			/>
+
+			<div className="flex flex-col md:mx-[5%] lg:mx-[15%]">
+				<div className="grid grid-cols-1 gap-4 px-4 md:px-12 pb-4 pt-10 w-full mx-auto">
+					<EmergencyCard />
+					<Card className="p-6 bg-card w-full flex flex-row">
+						<div className="text-xl font-semibold">{t("note_title")}</div>
+						{t("note_text")}
+					</Card>
+				</div>
+
+				<div className="flex-grow">
+					<div className="flex flex-col p-14 gap-4">
+						<CustomTitle text={t("board.self")} size={4} id="board" className="scroll-mt-20" />
+						<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+							<ContactCard
+								id="ordf"
+								title={t("board.ordf")}
+								fullName="Ester Hagberg Kuylenstierna"
+								email="ordf@fsektionen.se"
+								highlight={highlightedId === "ordf"}
+							/>
+							<ContactCard
+								id="vice"
+								title={t("board.vice")}
+								fullName="Lovisa Werselius"
+								email="viceordf@fsektionen.se "
+								highlight={highlightedId === "vice"}
+							/>
+							<ContactCard
+								id="preses"
+								title={t("board.preses")}
+								fullName="Malte Callsen"
+								email="preses@fsektionen.se"
+								highlight={highlightedId === "preses"}
+							/>
+							<ContactCard
+								id="secretary"
+								title={t("board.secretary")}
+								fullName="Hugo Klaesson"
+								email="sekreterare@fsektionen.se"
+								highlight={highlightedId === "secretary"}
+							/>
+							<ContactCard
+								id="board_members"
+								title={t("board.board_members")}
+								fullName="Rebecka Eldh, Sixten Georgsson, Samuel Eriksson, Elina Kazemi"
+								email="styrelseledamoter@fsektionen.se"
+								highlight={highlightedId === "board_members"}
+							/>
+						</div>
+
+						<CustomTitle text={t("other.self")} size={4} id="other" className="scroll-mt-20" />
+						<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+							<ContactCard
+								id="facilities"
+								title={t("other.facilities")}
+								fullName="Alva Rosberg"
+								email="prylm@fsektionen.se"
+								highlight={highlightedId === "facilities"}
+							/>
+							<ContactCard
+								id="car"
+								title={t("other.car")}
+								fullName="Vic Kowalik"
+								email="bil@fsektionen.se"
+								highlight={highlightedId === "car"}
+							/>
+							<ContactCard
+								id="festivities"
+								title={t("other.festivities")}
+								fullName="Ebba Wahlberg"
+								email="sex@fsektionen.se"
+								highlight={highlightedId === "festivities"}
+							/>
+							<ContactCard
+								id="truth"
+								title={t("other.truth")}
+								fullName="Albin Kårlin"
+								email="sanningsminister@fsektionen.se"
+								highlight={highlightedId === "truth"}
+							/>
+							<ContactCard
+								id="corp"
+								title={t("other.corp")}
+								fullName="David Mörtberg"
+								email="naringslivsansvarig@fsektionen.se"
+								highlight={highlightedId === "corp"}
+							/>
+							<ContactCard
+								id="overfos"
+								title={t("other.nollning")}
+								fullName="Överfös Victor"
+								email="overfos@fsektionen.se"
+								highlight={highlightedId === "overfos"}
+							/>
+							<ContactCard
+								id="cafe"
+								title={t("other.cafe")}
+								fullName="Ellen Boström"
+								email="cafe@fsektionen.se "
+								highlight={highlightedId === "cafe"}
+							/>
+							<ContactCard
+								id="conscience"
+								title={t("other.conscience")}
+								fullName="Alicia Ahlgren"
+								email="samvetsmastare@fsektionen.se"
+								highlight={highlightedId === "conscience"}
+							/>
+							<ContactCard
+								id="culture"
+								title={t("other.culture")}
+								fullName="Manne Mönster"
+								email="km@fsektionen.se "
+								highlight={highlightedId === "culture"}
+							/>
+							<ContactCard
+								id="education"
+								title={t("other.education")}
+								fullName="Mattis Mattsson"
+								email="um@fsektionen.se "
+								highlight={highlightedId === "education"}
+							/>
+							<ContactCard
+								id="treasurer"
+								title={t("other.treasurer")}
+								fullName="Anton Sundström"
+								email="kass@fsektionen.se"
+								highlight={highlightedId === "treasurer"}
+							/>
+						</div>
+
+						<CustomTitle text={t("corp.self")} size={4} id="foretag" className="scroll-mt-20" />
+						<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+							<ContactCard
+								id="naringslivsansvarig"
+								title={t("corp.naringslivsansvarig")}
+								fullName="David Mörtberg"
+								email="naringslivsansvarig@fsektionen.se"
+								highlight={highlightedId === "naringslivsansvarig"}
+							/>
+							<ContactCard
+								id="naringslivsutskottet"
+								title={t("corp.naringslivsutskottet")}
+								fullName={t("corp.naringslivsutskottet")}
+								email="naringslivsutskottet@fsektionen.se"
+								highlight={highlightedId === "naringslivsutskottet"}
+							/>
+							<ContactCard
+								id="farad"
+								title={t("corp.farad")}
+								fullName="Jacob Stelling"
+								email="farad@fsektionen.se"
+								highlight={highlightedId === "farad"}
+							/>
+						</div>
+
+						<CustomTitle text={t("web.self")} size={4} id="web" className="scroll-mt-20" />
+						<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+							<ContactCard
+								id="spindelforman"
+								title={t("web.spider")}
+								fullName="Manfred Malmros"
+								email="spindelforman@fsektionen.se"
+								highlight={highlightedId === "spindelforman"}
+							/>
+							<ContactCard
+								id="webmaster"
+								title={t("web.webmaster")}
+								fullName={t("web.webmaster_full_name")}
+								email="spindelman@fsektionen.se"
+								highlight={highlightedId === "webmaster"}
+							/>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div >
+	);
 }

--- a/src/app/i18n.tsx
+++ b/src/app/i18n.tsx
@@ -13,7 +13,8 @@ export type Namespace =
 	| "utskott"
 	| "landingpage"
 	| "user-settings"
-	| "notfound";
+	| "notfound"
+	| "contact";
 
 // If you add more you probably also have to add them to the layout.tsx file corresponding to the page you are on
 // (or only the main one, try that first)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,7 @@ const i18nNamespaces = [
 	"landingpage",
 	"user-settings",
 	"notfound",
+	"contact",
 ] satisfies Namespace[];
 
 export default async function RootLayout({

--- a/src/components/CustomTitle.tsx
+++ b/src/components/CustomTitle.tsx
@@ -10,6 +10,7 @@ interface CustomTitleProps {
 	fullUnderline?: boolean;
 	shortUnderline?: boolean;
 	noUnderline?: boolean;
+	id?: string;
 }
 
 const CustomTitle: FC<CustomTitleProps> = ({
@@ -20,6 +21,7 @@ const CustomTitle: FC<CustomTitleProps> = ({
 	fullUnderline,
 	shortUnderline = false,
 	noUnderline = false,
+	id,
 }) => {
 	const [animationState, setAnimationState] = useState<
 		"initial" | "text-width" | "full-width"
@@ -94,6 +96,7 @@ const CustomTitle: FC<CustomTitleProps> = ({
 		<div className="w-full py-5">
 			<div
 				ref={textRef}
+				id={id}
 				className={`inline-block font-bold text-left  to-primary-light from-primary bg-gradient-to-t text-transparent bg-clip-text bg-bottom ${getSizeClass()} ${className} ${shortUnderline ? "underline" : ""}`}
 			>
 				{text ?? children ?? "Default title"}

--- a/src/components/landing/Footer.tsx
+++ b/src/components/landing/Footer.tsx
@@ -84,13 +84,13 @@ export const Footer = () => {
 					</div>
 
 					<div>
-						<Link href="/contact" className="opacity-60 hover:opacity-100">
+						<Link href="/contact#ordf" className="opacity-60 hover:opacity-100">
 							{t("footer.contact_ordf")}
 						</Link>
 					</div>
 
 					<div>
-						<Link href="/contact" className="opacity-60 hover:opacity-100">
+						<Link href="/contact#webmaster" className="opacity-60 hover:opacity-100">
 							{t("footer.contact_webmaster")}
 						</Link>
 					</div>

--- a/src/locales/en/contact.json
+++ b/src/locales/en/contact.json
@@ -1,0 +1,55 @@
+{
+	"title": "Contact Us",
+	"note_title": "Note:",
+	"note_text": "Not all contact links are available on this page. If you are a member, you can go to the council page to find all contact links. Otherwise, contact a council chairperson and ask them to forward your message.",
+	"emergency": {
+		"title": "Emergency Contacts",
+		"text_ordf": {
+			"self": "For general emergencies: ",
+			"name": "President"
+		},
+		"text_foset": {
+			"self": "For emergencies during the introduction period: "
+		},
+		"text_car": {
+			"self": "For emergencies involving the F-car: ",
+			"name1": "Car Foreman",
+			"name2": "Head of Facilities",
+			"name3": "President"
+		}
+	},
+	"board": {
+		"self": "The Board",
+		"ordf": "President",
+		"vice": "Vice President",
+		"preses": "Chair of the Board",
+		"secretary": "Secretary",
+		"board_members": "Board Members"
+	},
+	"other": {
+		"self": "Other Contacts",
+		"facilities": "Head of Facilities",
+		"car": "Car Foreman",
+		"festivities": "Head of Festivities",
+		"truth": "Minister of Truth",
+		"corp": "Head of Corporate Relations",
+		"nollning": "Överfös",
+		"cafe": "Managing Director of Hilbert Café",
+		"conscience": "The Master of the Conscience",
+		"culture": "Minister for Culture",
+		"education": "Minister for Education",
+		"treasurer": "Treasurer"
+	},
+	"corp": {
+		"self": "For corporate inquiries",
+		"naringslivsansvarig": "Head of Corporate Relations",
+		"naringslivsutskottet": "Corporate Relations Committee",
+		"farad": "Project Manager of FARAD"
+	},
+	"web": {
+		"self": "For web-related inquiries",
+		"spider": "Spider master",
+		"webmaster": "Webmaster",
+		"webmaster_full_name": "With great power..."
+	}
+}

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -150,7 +150,8 @@
 			},
 			"contact": {
 				"self": "Business Contact",
-				"desc": "Reach out to us for partnership and business inquiries."
+				"desc": "Reach out to us for partnership and business inquiries.",
+				"href": "/contact#naringslivsutskottet"
 			}
 		},
 		"contact": {
@@ -158,17 +159,17 @@
 			"contactPage": {
 				"self": "Contact Page",
 				"desc": "Find all the information you need to get in touch with us.",
-				"href": "https://old.fsektionen.se/kontakter"
+				"href": "/contact"
 			},
 			"ordf": {
 				"self": "President",
 				"desc": "For questions about the organisation.",
-				"href": "https://old.fsektionen.se/kontakter/19"
+				"href": "/contact#ordf"
 			},
 			"web": {
 				"self": "Webmaster",
 				"desc": "For questions about the website or app.",
-				"href": "mailto:spindelman@fsektionen.se"
+				"href": "/contact#webmaster"
 			},
 			"anonymousForm": {
 				"self": "Anonymous Contact",

--- a/src/locales/sv/contact.json
+++ b/src/locales/sv/contact.json
@@ -1,0 +1,55 @@
+{
+	"title": "Kontakta Oss",
+	"note_title": "Notera:",
+	"note_text": "Inte alla kontaktlänkar är tillgängliga på denna sida. Om du är medlem kan du gå till utskottssidan för att hitta alla kontaktlänkar. Annars kan du kontakta en ordförande för utskottet och be dem vidarebefordra ditt meddelande.",
+	"emergency": {
+		"title": "Nödkontakter",
+		"text_ordf": {
+			"self": "Vid allmänna nödsituationer: ",
+			"name": "Ordförande"
+		},
+		"text_foset": {
+			"self": "Vid nödsituationer under nollningen: "
+		},
+		"text_car": {
+			"self": "Vid nödsituationer med F-bilen: ",
+			"name1": "Bilförman",
+			"name2": "Prylmästare",
+			"name3": "Ordförande"
+		}
+	},
+	"board": {
+		"self": "Styrelsen",
+		"ordf": "Ordförande",
+		"vice": "Vice ordförande",
+		"preses": "Styrelsepreses",
+		"secretary": "Sekreterare",
+		"board_members": "Styrelseledamöter"
+	},
+	"other": {
+		"self": "Andra Kontakter",
+		"facilities": "Prylmästare",
+		"car": "Bilförman",
+		"festivities": "Sexmästare",
+		"truth": "Sanningsminister",
+		"corp": "Näringslivsansvarig",
+		"nollning": "Överfös",
+		"cafe": "Cafémästare",
+		"conscience": "Samvetsmästare",
+		"culture": "Kulturminister",
+		"education": "Utbildningsminister",
+		"treasurer": "Kassör"
+	},
+	"corp": {
+		"self": "För företag",
+		"naringslivsansvarig": "Näringslivsansvarig",
+		"naringslivsutskottet": "Näringslivsutskottet",
+		"farad": "Projektledare FARAD"
+	},
+	"web": {
+		"self": "För webbrelaterade frågor",
+		"spider": "Spindelförman",
+		"webmaster": "Spindelmän",
+		"webmaster_full_name": "Kontrollerar detta nät"
+	}
+}

--- a/src/locales/sv/main.json
+++ b/src/locales/sv/main.json
@@ -150,7 +150,8 @@
 			},
 			"contact": {
 				"self": "Företagskontakt",
-				"desc": "Kontakta oss för affärsförfrågningar och samarbeten."
+				"desc": "Kontakta oss för affärsförfrågningar och samarbeten.",
+				"href": "/contact#naringslivsutskottet"
 			}
 		},
 		"contact": {
@@ -158,17 +159,17 @@
 			"contactPage": {
 				"self": "Kontaktsida",
 				"desc": "Här hittar du all information du behöver för att nå oss.",
-				"href": "https://old.fsektionen.se/kontakter"
+				"href": "/contact"
 			},
 			"ordf": {
 				"self": "Ordförande",
 				"desc": "För frågor om organisationen.",
-				"href": "https://old.fsektionen.se/kontakter/19"
+				"href": "/contact#ordf"
 			},
 			"web": {
 				"self": "Webbansvarig",
 				"desc": "För frågor om vår webbplats eller app.",
-				"href": "mailto:spindelman@fsektionen.se"
+				"href": "/contact#webmaster"
 			},
 			"anonymousForm": {
 				"self": "Anonymt kontaktformulär",


### PR DESCRIPTION
Ready to push I think. No backend changes required because all the fields are hardcoded, which we'll have to change later because updating this I think will be boring.

Features:
- Looks all right
- Uses obfuscation when facing the web so there's a slightly smaller risk of bot scraping, no obfuscation of the source code though :(.
- When we have images it should fit right in into the design
- Quite a bit more code duplication than I'd like
- Use #ordf for example to go to a specific contact card and highlight it
- Use #board for example to go to a category
- Cards for all(?) council chairpersons and all roles in the board + companies and web contacts
- Updated a bunch of links so we have nothing pointing to the old contact page
- Emergency card with emergency numbers like before