### PR TITLE
Fix bug which made it impossible to select dates 

### DIFF
--- a/src/components/ui/datetime-picker.tsx
+++ b/src/components/ui/datetime-picker.tsx
@@ -5,7 +5,7 @@ import {
 	Popover,
 	PopoverContent,
 	PopoverTrigger,
-} from "@/components/ui/popover-no-portal";
+} from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { add, format } from "date-fns";
 import { type Locale, enUS } from "date-fns/locale";
@@ -862,7 +862,7 @@ const DateTimePicker = React.forwardRef<
 						// This is a workaround for radix-ui not allowing fallback side selection
 						// see: https://github.com/radix-ui/primitives/issues/3101
 						typeof window !== "undefined" && window.innerHeight > 700
-							? "top"
+							? "bottom"
 							: "right"
 					}
 				>


### PR DESCRIPTION
We previously stopped using popover in favor of a version without a portal (popover-no-portal) to fix a bug where the datepicker would not open at all. I don't see this being a problem anymore and many other components already use the portal popover so I switched it back. This also fixes a range of bugs where the date picker would clip out of bounds of the alertdialog we use for forms, leading to unnecessary scrolling or some parts of the date picker not being selectable. 