### PR TITLE
Add more group types to select and "default" group member type

### DIFF
--- a/src/app/admin/nollning/admin-nollning/group-users/page.tsx
+++ b/src/app/admin/nollning/admin-nollning/group-users/page.tsx
@@ -81,6 +81,9 @@ export default function GroupUsersPage() {
 				if (groupUserType === "Mentee") {
 					return t("nollning.group_members.nolla");
 				}
+				if (groupUserType === "Default") {
+					return t("nollning.group_members.standard");
+				}
 				return groupUserType;
 			},
 		}),
@@ -155,16 +158,16 @@ export default function GroupUsersPage() {
 		<Suspense
 			fallback={
 				<div>
-					<h3>
-						{t("nollning.group_members.no_group_selected")}
-					</h3>
+					<h3>{t("nollning.group_members.no_group_selected")}</h3>
 				</div>
 			}
 		>
 			<div className="px-12 py-4  space-y-4 ">
 				<div className="justify-between w-full flex flex-row">
 					<h3 className="text-3xl py-3 font-bold text-primary">
-						{t("nollning.group_members.header_group_members", { group: group.data.name })}
+						{t("nollning.group_members.header_group_members", {
+							group: group.data.name,
+						})}
 					</h3>
 					<Button
 						variant="ghost"
@@ -194,9 +197,13 @@ export default function GroupUsersPage() {
 							</div>
 							<div className="border border-card-foreground/20 rounded-lg bg-card mb-5 mx-5 w-sm">
 								<div className="space-x-4 space-y-4 flex-2 p-4">
-									<h3 className="text-xl">{t("nollning.group_members.info_header")}</h3>
+									<h3 className="text-xl">
+										{t("nollning.group_members.info_header")}
+									</h3>
 									<p className="text-sm text-muted-foreground">
-										{t("nollning.group_members.info_text", { group: group.data.name })}
+										{t("nollning.group_members.info_text", {
+											group: group.data.name,
+										})}
 									</p>
 								</div>
 							</div>
@@ -234,7 +241,9 @@ export default function GroupUsersPage() {
 										<Button variant="destructive" onClick={handleRemoveUser}>
 											{t("nollning.group_members.remove")}
 										</Button>
-										<DialogClose>{t("nollning.group_members.cancel")}</DialogClose>
+										<DialogClose>
+											{t("nollning.group_members.cancel")}
+										</DialogClose>
 									</div>
 								</DialogFooter>
 							</DialogContent>
@@ -244,4 +253,4 @@ export default function GroupUsersPage() {
 			</div>
 		</Suspense>
 	);
-};
+}

--- a/src/app/admin/nollning/admin-nollning/group-users/searchBar.tsx
+++ b/src/app/admin/nollning/admin-nollning/group-users/searchBar.tsx
@@ -79,6 +79,9 @@ export default function SearchBar({
 					<SelectItem value="Mentor">
 						{t("nollning.group_members.add_as_mentor")}
 					</SelectItem>
+					<SelectItem value="Default">
+						{t("nollning.group_members.add_as_standard")}
+					</SelectItem>
 				</SelectContent>
 			</Select>
 			<Select

--- a/src/app/admin/nollning/admin-nollning/groups/CreateGroup.tsx
+++ b/src/app/admin/nollning/admin-nollning/groups/CreateGroup.tsx
@@ -34,7 +34,7 @@ import { useTranslation } from "react-i18next";
 
 const GroupSchema = z.object({
 	name: z.string().min(2),
-	group_type: z.enum(["Mentor", "Mission"]),
+	group_type: z.enum(["Mentor", "Mission", "Default", "Committee"]),
 	mentor_group_number: z.coerce.number().min(1).optional(),
 });
 
@@ -45,9 +45,9 @@ interface Props {
 
 const CreateAdventureMission = ({ nollningID, className }: Props) => {
 	const [open, setOpen] = useState(false);
-	const [pendingGroupNumber, setPendingGroupNumber] = useState<number | undefined>(
-		undefined
-	);
+	const [pendingGroupNumber, setPendingGroupNumber] = useState<
+		number | undefined
+	>(undefined);
 
 	const groupForm = useForm<z.infer<typeof GroupSchema>>({
 		resolver: zodResolver(GroupSchema),
@@ -146,7 +146,10 @@ const CreateAdventureMission = ({ nollningID, className }: Props) => {
 										<FormItem>
 											<FormLabel>{t("nollning.groups.title")}</FormLabel>
 											<FormControl>
-												<Input placeholder={t("nollning.groups.title")} {...field} />
+												<Input
+													placeholder={t("nollning.groups.title")}
+													{...field}
+												/>
 											</FormControl>
 										</FormItem>
 									)}
@@ -175,9 +178,11 @@ const CreateAdventureMission = ({ nollningID, className }: Props) => {
 													type="number"
 													placeholder={t("nollning.groups.group_number")}
 													value={field.value === undefined ? "" : field.value}
-													onChange={e => {
+													onChange={(e) => {
 														const val = e.target.value;
-														field.onChange(val === "" ? undefined : Number(val));
+														field.onChange(
+															val === "" ? undefined : Number(val),
+														);
 													}}
 												/>
 											</FormControl>

--- a/src/app/admin/nollning/admin-nollning/groups/GroupTypeSelect.tsx
+++ b/src/app/admin/nollning/admin-nollning/groups/GroupTypeSelect.tsx
@@ -19,8 +19,12 @@ const GroupTypeSelect = ({ value, onChange }: Props) => {
 	const groupTypes: { [key: string]: string } = {
 		Fadder: "Mentor",
 		Uppdrag: "Mission",
+		Standard: "Default",
+		Utskott: "Committee",
 		Mentor: "Mentor",
 		Mission: "Mission",
+		Default: "Default",
+		Committee: "Committee",
 	};
 
 	return (
@@ -30,7 +34,12 @@ const GroupTypeSelect = ({ value, onChange }: Props) => {
 			</SelectTrigger>
 			<SelectContent>
 				<SelectGroup>
-					{[t("nollning.groups.fadder"), t("nollning.groups.uppdrag")]?.map((item) => (
+					{[
+						t("nollning.groups.fadder"),
+						t("nollning.groups.uppdrag"),
+						t("nollning.groups.standard"),
+						t("nollning.groups.utskott"),
+					]?.map((item) => (
 						<SelectItem key={item} value={groupTypes[item]}>
 							{item || t("unnamed_council")}
 						</SelectItem>

--- a/src/app/admin/nollning/admin-nollning/page.tsx
+++ b/src/app/admin/nollning/admin-nollning/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { getNollningByYearOptions, getNollningOptions } from "@/api/@tanstack/react-query.gen";
+import {
+	getNollningByYearOptions,
+	getNollningOptions,
+} from "@/api/@tanstack/react-query.gen";
 import React, { Suspense, useMemo, useState } from "react";
 import type { GroupRead, NollningGroupRead } from "@/api";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -29,12 +32,16 @@ export default function Page() {
 
 	const { data } =
 		idParam === null || idParam === "current"
-			? useSuspenseQuery(getNollningByYearOptions({
-				path: { year: new Date().getFullYear() },
-			}))
-			: useSuspenseQuery(getNollningOptions({
-				path: { nollning_id: nollningID },
-			}));
+			? useSuspenseQuery(
+					getNollningByYearOptions({
+						path: { year: new Date().getFullYear() },
+					}),
+				)
+			: useSuspenseQuery(
+					getNollningOptions({
+						path: { nollning_id: nollningID },
+					}),
+				);
 
 	// After getting the data, switch the parameter to nollningID, to make it easier to pass down
 	if (idParam === null || idParam === "current") {
@@ -47,11 +54,14 @@ export default function Page() {
 		// Filter by search term if provided
 		if (searchTerm.trim() !== "") {
 			const term = searchTerm.toLowerCase();
-			groups = groups.filter((group) =>
-			(group.group.name?.toLowerCase().includes(term) ||
-				group.group.group_users.some((user) =>
-					(`${user.user.first_name} ${user.user.last_name}`).toLowerCase().includes(term)
-				))
+			groups = groups.filter(
+				(group) =>
+					group.group.name?.toLowerCase().includes(term) ||
+					group.group.group_users.some((user) =>
+						`${user.user.first_name} ${user.user.last_name}`
+							.toLowerCase()
+							.includes(term),
+					),
 			);
 		}
 		return groups;
@@ -82,6 +92,10 @@ export default function Page() {
 						return t("nollning.group_admin.fadder");
 					case "Mission":
 						return t("nollning.group_admin.uppdrag");
+					case "Default":
+						return t("nollning.group_admin.standard");
+					case "Committee":
+						return t("nollning.group_admin.utskott");
 					default:
 						return t("nollning.group_admin.unknown_type");
 				}
@@ -103,7 +117,9 @@ export default function Page() {
 						size="sm"
 						onClick={(e) => {
 							e.stopPropagation();
-							router.push(`/admin/nollning/admin-nollning/completed-missions?id=${nollningID}&group=${row.original.group.id}`);
+							router.push(
+								`/admin/nollning/admin-nollning/completed-missions?id=${nollningID}&group=${row.original.group.id}`,
+							);
 						}}
 					>
 						{t("nollning.group_admin.to_missions")}
@@ -114,7 +130,9 @@ export default function Page() {
 						className="text-foreground"
 						onClick={(e) => {
 							e.stopPropagation();
-							router.push(`/admin/nollning/admin-nollning/group-users?id=${nollningID}&group=${row.original.group.id}`);
+							router.push(
+								`/admin/nollning/admin-nollning/group-users?id=${nollningID}&group=${row.original.group.id}`,
+							);
 						}}
 					>
 						{t("nollning.group_admin.to_members")}
@@ -148,7 +166,9 @@ export default function Page() {
 	};
 
 	return (
-		<Suspense fallback={<div>{t("nollning.group_admin.no_nollning_selected")}</div>}>
+		<Suspense
+			fallback={<div>{t("nollning.group_admin.no_nollning_selected")}</div>}
+		>
 			<div className="px-12 py-4 space-x-4 space-y-4">
 				<div className="justify-between w-full flex flex-row">
 					<h3 className="text-3xl py-3 font-bold text-primary">
@@ -163,9 +183,7 @@ export default function Page() {
 						{t("nollning.group_admin.back")}
 					</Button>
 				</div>
-				<p className="">
-					{t("nollning.group_admin.intro")}
-				</p>
+				<p className="">{t("nollning.group_admin.intro")}</p>
 				<div className="space-x-2 lg:col-span-2 flex">
 					<Button className="w-32 min-w-fit" onClick={adminAdventureMissions}>
 						{t("nollning.group_admin.admin_missions")}
@@ -173,9 +191,7 @@ export default function Page() {
 					<CreateGroup className="w-32 min-w-fit" nollningID={nollningID} />
 				</div>
 				<div className="flex flex-row gap-3 items-center">
-					<span>
-						{t("nollning.group_admin.filter_label")}
-					</span>
+					<span>{t("nollning.group_admin.filter_label")}</span>
 					<Input
 						type="text"
 						placeholder={t("nollning.group_admin.search_placeholder")}

--- a/src/app/admin/nollning/nollningAccordionItem.tsx
+++ b/src/app/admin/nollning/nollningAccordionItem.tsx
@@ -24,11 +24,13 @@ const NollningAccordionItem = ({ nollning }: Props) => {
 
 	return (
 		<AccordionItem
-			className="w-full border-b transition duration-200 hover:bg-gray-50"
+			className="w-full border-b transition duration-200 hover:bg-secondary"
 			value={nollning.id.toString()}
 		>
 			<AccordionTrigger className="flex w-full px-4">
-				<p className="text-base">{nollning.year} - {nollning.name}</p>
+				<p className="text-base">
+					{nollning.year} - {nollning.name}
+				</p>
 			</AccordionTrigger>
 			<AccordionContent className="w-full px-4 space-y-4">
 				<div>

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -506,6 +506,8 @@
 			"members_btn": "Members",
 			"fadder": "Mentor",
 			"uppdrag": "Mission",
+			"standard": "Default",
+			"utskott": "Council",
 			"unknown_type": "Unknown Type"
 		},
 		"groups": {
@@ -521,6 +523,8 @@
 			"cancel": "Cancel",
 			"fadder": "Mentor",
 			"uppdrag": "Mission",
+			"standard": "Default",
+			"utskott": "Council",
 			"create_success": "Group created!",
 			"create_error": "Could not create group.",
 			"add_success": "Group added to introduction!",
@@ -618,6 +622,7 @@
 			"select_role_placeholder": "Select role",
 			"add_as_mentee": "Add as mentee",
 			"add_as_mentor": "Add as mentor",
+			"add_as_standard": "Add as default member",
 			"filter_by_program": "Filter by program",
 			"clear": "Clear",
 			"search_user_placeholder": "Search user",
@@ -628,6 +633,7 @@
 			"no_years_found": "No years found",
 			"fadder": "Mentor",
 			"nolla": "Mentee",
+			"standard": "Default member",
 			"unclear": "Unclear"
 		}
 	},

--- a/src/locales/sv/admin.json
+++ b/src/locales/sv/admin.json
@@ -507,6 +507,8 @@
 			"members_btn": "Medlemmar",
 			"fadder": "Fadder",
 			"uppdrag": "Uppdrag",
+			"standard": "Standard",
+			"utskott": "Utskott",
 			"unknown_type": "Okänd typ"
 		},
 		"groups": {
@@ -522,6 +524,8 @@
 			"cancel": "Avbryt",
 			"fadder": "Fadder",
 			"uppdrag": "Uppdrag",
+			"standard": "Standard",
+			"utskott": "Utskott",
 			"create_success": "Grupp skapad!",
 			"create_error": "Kunde inte skapa grupp.",
 			"add_success": "Grupp tillagd i nollning!",
@@ -619,6 +623,7 @@
 			"select_role_placeholder": "Välj roll",
 			"add_as_mentee": "Lägg till som nolla",
 			"add_as_mentor": "Lägg till som fadder",
+			"add_as_standard": "Lägg till som standardmedlem",
 			"filter_by_program": "Filtrera efter program",
 			"clear": "Rensa",
 			"search_user_placeholder": "Sök användare",
@@ -629,6 +634,7 @@
 			"no_years_found": "Inga år hittades",
 			"fadder": "Fadder",
 			"nolla": "Nolla",
+			"standard": "Standardmedlem",
 			"unclear": "Oklart"
 		}
 	},


### PR DESCRIPTION
Fix which allows nollning admins to pick non nollning group types for whatever groups they need to add, so they don't show up in any lists we make later.