### PR TITLE
Horrible fix to add html linebreaks automatically to event descriptions

### DIFF
--- a/src/app/(public)/calendar/event-details/page.tsx
+++ b/src/app/(public)/calendar/event-details/page.tsx
@@ -29,6 +29,7 @@ import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
 import type { EventRead } from "@/api/types.gen";
 import SignupCard from "./SignupCard";
+import stripHtmlLinebreaks from "@/help_functions/stripHtmlLinebreaks";
 
 function idAsNumber(value: string | null): number {
 	if (value === null || value.trim() === "") return -1;
@@ -119,9 +120,11 @@ export default function Page() {
 									{t("admin:description")}
 								</p>
 								<p className="text-muted-foreground whitespace-pre-wrap">
-									{i18n.language === "en"
-										? data.description_en
-										: data.description_sv}
+									{stripHtmlLinebreaks(
+										i18n.language === "en"
+											? data.description_en
+											: data.description_sv,
+									)}
 								</p>
 							</div>
 

--- a/src/app/(public)/calendar/subscribe/route.ts
+++ b/src/app/(public)/calendar/subscribe/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
+import stripHtmlLinebreaks from "@/help_functions/stripHtmlLinebreaks";
 
 interface EventExtendedProps {
 	description?: string;
@@ -140,7 +141,7 @@ async function fetchLatestEvents() {
 					end: event.ends_at,
 					allDay: event.all_day,
 					extendedProps: {
-						description: event.description_sv,
+						description: stripHtmlLinebreaks(event.description_sv),
 						location: event.location,
 					},
 				}))

--- a/src/app/admin/events/EventsEditForm.tsx
+++ b/src/app/admin/events/EventsEditForm.tsx
@@ -19,6 +19,7 @@ import { ConfirmDeleteDialog } from "@/components/ConfirmDeleteDialog";
 import { List, Save } from "lucide-react";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
+import addHtmlLinebreaks from "@/help_functions/addHtmlLinebreaks";
 
 const eventsEditSchema = z.object({
 	id: z.number(),
@@ -157,6 +158,9 @@ export default function EventsEditForm({
 	function handleFormSubmit(values: EventsEditFormValues) {
 		const updatedEvent: EventUpdate = {
 			...values,
+			// add html line breaks in descriptions before sending
+			description_sv: addHtmlLinebreaks(values.description_sv),
+			description_en: addHtmlLinebreaks(values.description_en),
 			priorities: values.priorities as EventUpdate["priorities"],
 		};
 

--- a/src/app/admin/events/EventsForm.tsx
+++ b/src/app/admin/events/EventsForm.tsx
@@ -15,6 +15,7 @@ import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import type { EventCreate } from "@/api/types.gen";
 import EventFormFields from "./EventFormFields";
+import addHtmlLinebreaks from "@/help_functions/addHtmlLinebreaks";
 
 const eventsSchema = z
 	.object({
@@ -136,8 +137,8 @@ export default function EventsForm() {
 				ends_at: values.ends_at,
 				signup_start: values.signup_start,
 				signup_end: values.signup_end,
-				description_sv: values.description_sv,
-				description_en: values.description_en,
+				description_sv: addHtmlLinebreaks(values.description_sv),
+				description_en: addHtmlLinebreaks(values.description_en),
 				location: values.location,
 				max_event_users: values.max_event_users,
 				priorities: values.priorities as EventCreate["priorities"],

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -29,6 +29,8 @@ import { Separator } from "@/components/ui/separator";
 import Calendar from "@/components/full-calendar";
 import { useRouter } from "next/navigation";
 import { LoadingErrorCard } from "@/components/LoadingErrorCard";
+import stripHtmlLinebreaks from "@/help_functions/stripHtmlLinebreaks";
+import addHtmlLinebreaks from "@/help_functions/addHtmlLinebreaks";
 
 // Column setup
 const columnHelper = createColumnHelper<EventRead>();
@@ -90,7 +92,13 @@ export default function Events() {
 	});
 
 	function handleRowClick(row: Row<EventRead>) {
-		setSelectedEvent(row.original);
+		// Ensure descriptions are provided as plain text to the edit form
+		const processed = {
+			...row.original,
+			description_sv: stripHtmlLinebreaks(row.original.description_sv ?? ""),
+			description_en: stripHtmlLinebreaks(row.original.description_en ?? ""),
+		};
+		setSelectedEvent(processed);
 		setOpenEditDialog(true);
 	}
 
@@ -192,8 +200,8 @@ export default function Events() {
 			signup_start: event.signup_start,
 			signup_end: event.signup_end,
 			all_day: event.all_day,
-			description_sv: event.description_sv,
-			description_en: event.description_en,
+			description_sv: stripHtmlLinebreaks(event.description_sv),
+			description_en: stripHtmlLinebreaks(event.description_en),
 			location: event.location,
 			max_event_users: event.max_event_users,
 			priorities: event.priorities.map(
@@ -235,8 +243,10 @@ export default function Events() {
 								signup_end: event.signup_end as Date,
 								title_sv: event.title_sv,
 								title_en: event.title_en as string,
-								description_sv: event.description_sv,
-								description_en: event.description_en as string,
+								description_sv: addHtmlLinebreaks(event.description_sv),
+								description_en: addHtmlLinebreaks(
+									event.description_en as string,
+								),
 								location: event.location as string,
 								max_event_users: event.max_event_users as number,
 								priorities: event.priorities as EventCreate["priorities"], // This might just work
@@ -286,8 +296,10 @@ export default function Events() {
 								signup_end: event.signup_end as Date,
 								title_sv: event.title_sv,
 								title_en: event.title_en as string,
-								description_sv: event.description_sv,
-								description_en: event.description_en as string,
+								description_sv: addHtmlLinebreaks(event.description_sv),
+								description_en: addHtmlLinebreaks(
+									event.description_en as string,
+								),
 								location: event.location as string,
 								max_event_users: event.max_event_users as number,
 								all_day: event.all_day as boolean,

--- a/src/components/main-page-calendar.tsx
+++ b/src/components/main-page-calendar.tsx
@@ -10,6 +10,7 @@ import type {
 import type { EventCreate, EventRead } from "@/api";
 import { useRouter } from "next/navigation";
 import { LoadingErrorCard } from "./LoadingErrorCard";
+import stripHtmlLinebreaks from "@/help_functions/stripHtmlLinebreaks";
 
 interface MainPageCalendarProps {
 	mini?: boolean;
@@ -79,8 +80,8 @@ export default function MainPageCalendar({
 			signup_start: event.signup_start,
 			signup_end: event.signup_end,
 			all_day: event.all_day,
-			description_sv: event.description_sv,
-			description_en: event.description_en,
+			description_sv: stripHtmlLinebreaks(event.description_sv),
+			description_en: stripHtmlLinebreaks(event.description_en),
 			location: event.location,
 			max_event_users: event.max_event_users,
 			priorities: event.priorities.map(

--- a/src/help_functions/addHtmlLinebreaks.ts
+++ b/src/help_functions/addHtmlLinebreaks.ts
@@ -1,0 +1,8 @@
+// Helper to add HTML linebreaks to descriptions
+export default function addHtmlLinebreaks(
+	value: string | null | undefined,
+): string {
+	if (!value) return "";
+	// Add html newlines where they should be
+	return value.replace(/\n/g, "<br />\n");
+}

--- a/src/help_functions/stripHtmlLinebreaks.ts
+++ b/src/help_functions/stripHtmlLinebreaks.ts
@@ -1,0 +1,8 @@
+// Helper to strip HTML linebreaks from descriptions
+export default function stripHtmlLinebreaks(
+	value: string | null | undefined,
+): string {
+	if (!value) return "";
+	// Remove <br>, <br/> and <br /> (case-insensitive)
+	return value.replace(/<br\s*\/?>/gi, "");
+}


### PR DESCRIPTION
This should be reverted before the week is up, as soon as the app gets its fix pushed.