### PR TITLE
Correct room booking times

### DIFF
--- a/src/app/admin/room-bookings/page.tsx
+++ b/src/app/admin/room-bookings/page.tsx
@@ -76,9 +76,13 @@ export default function RoomBookings() {
 	const [visibleDateRange, setVisibleDateRange] = useState<{
 		start: Date;
 		end: Date;
-	}>({
-		start: new Date(),
-		end: new Date(),
+	}>(() => {
+		const start = new Date();
+		start.setSeconds(0, 0);
+		const end = new Date();
+		end.setSeconds(0, 0);
+
+		return { start, end };
 	});
 
 	// Getting all bookings at once is not efficient, but even testing with around 20 000 bookings (3 a day for 18 years) and


### PR DESCRIPTION
Fixed so that a room is booked from the time chosen and not a few seconds later (depending on the time that you made the booking).

Unfortunately I didn't know how to test this because the test page wouldn't let me log in? Maybe I am doing something wrong. Anyways, it is very few lines.