### PR TITLE
Removed the addition of linebreaks to event descriptions

### DIFF
--- a/src/app/admin/events/EventsEditForm.tsx
+++ b/src/app/admin/events/EventsEditForm.tsx
@@ -19,7 +19,6 @@ import { ConfirmDeleteDialog } from "@/components/ConfirmDeleteDialog";
 import { List, Save } from "lucide-react";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
-import addHtmlLinebreaks from "@/help_functions/addHtmlLinebreaks";
 
 const eventsEditSchema = z.object({
 	id: z.number(),
@@ -158,9 +157,8 @@ export default function EventsEditForm({
 	function handleFormSubmit(values: EventsEditFormValues) {
 		const updatedEvent: EventUpdate = {
 			...values,
-			// add html line breaks in descriptions before sending
-			description_sv: addHtmlLinebreaks(values.description_sv),
-			description_en: addHtmlLinebreaks(values.description_en),
+			description_sv: values.description_sv,
+			description_en: values.description_en,
 			priorities: values.priorities as EventUpdate["priorities"],
 		};
 

--- a/src/app/admin/events/EventsForm.tsx
+++ b/src/app/admin/events/EventsForm.tsx
@@ -15,7 +15,6 @@ import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import type { EventCreate } from "@/api/types.gen";
 import EventFormFields from "./EventFormFields";
-import addHtmlLinebreaks from "@/help_functions/addHtmlLinebreaks";
 
 const eventsSchema = z
 	.object({
@@ -137,8 +136,8 @@ export default function EventsForm() {
 				ends_at: values.ends_at,
 				signup_start: values.signup_start,
 				signup_end: values.signup_end,
-				description_sv: addHtmlLinebreaks(values.description_sv),
-				description_en: addHtmlLinebreaks(values.description_en),
+				description_sv: values.description_sv,
+				description_en: values.description_en,
 				location: values.location,
 				max_event_users: values.max_event_users,
 				priorities: values.priorities as EventCreate["priorities"],

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -30,7 +30,6 @@ import Calendar from "@/components/full-calendar";
 import { useRouter } from "next/navigation";
 import { LoadingErrorCard } from "@/components/LoadingErrorCard";
 import stripHtmlLinebreaks from "@/help_functions/stripHtmlLinebreaks";
-import addHtmlLinebreaks from "@/help_functions/addHtmlLinebreaks";
 
 // Column setup
 const columnHelper = createColumnHelper<EventRead>();
@@ -243,10 +242,8 @@ export default function Events() {
 								signup_end: event.signup_end as Date,
 								title_sv: event.title_sv,
 								title_en: event.title_en as string,
-								description_sv: addHtmlLinebreaks(event.description_sv),
-								description_en: addHtmlLinebreaks(
-									event.description_en as string,
-								),
+								description_sv: event.description_sv,
+								description_en: event.description_en as string,
 								location: event.location as string,
 								max_event_users: event.max_event_users as number,
 								priorities: event.priorities as EventCreate["priorities"], // This might just work
@@ -296,10 +293,8 @@ export default function Events() {
 								signup_end: event.signup_end as Date,
 								title_sv: event.title_sv,
 								title_en: event.title_en as string,
-								description_sv: addHtmlLinebreaks(event.description_sv),
-								description_en: addHtmlLinebreaks(
-									event.description_en as string,
-								),
+								description_sv: event.description_sv,
+								description_en: event.description_en as string,
 								location: event.location as string,
 								max_event_users: event.max_event_users as number,
 								all_day: event.all_day as boolean,

--- a/src/help_functions/addHtmlLinebreaks.ts
+++ b/src/help_functions/addHtmlLinebreaks.ts
@@ -1,4 +1,5 @@
 // Helper to add HTML linebreaks to descriptions
+// No longer used, this was a temporary fix
 export default function addHtmlLinebreaks(
 	value: string | null | undefined,
 ): string {


### PR DESCRIPTION
This was a temporary fix to resolve an issue in the app. Now that the app has been fixed we no longer need it, in fact it is causing the same problem the app had before *because* we have this fix in place.