### PR TITLE
Remove extra F-sektionen in Footer.

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -127,7 +127,7 @@ export function Footer() {
 				</div>
 
 				<div className="text-center">
-					&copy; {new Date().getFullYear()} F-sektionen. {t("footer.copyright")}
+					&copy; {new Date().getFullYear()} {t("footer.copyright")}
 				</div>
 			</div>
 		</footer>


### PR DESCRIPTION
This is a fix for #245. The hardcoded "F-sektionen" text in component "Footer" has been removed. 