### PR TITLE
Update permission system and permission wall to the new system 

### DIFF
--- a/src/app/(public)/account-settings/page.tsx
+++ b/src/app/(public)/account-settings/page.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/ui/form";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import ChangeEmailPassForm from "@/components/ChangeEmailPassForm";
+import getErrorMessage from "@/help_functions/getErrorMessage";
 
 export default function AccountSettingsPage() {
 	const { t } = useTranslation("user-settings");
@@ -116,13 +117,7 @@ export default function AccountSettingsPage() {
 			toast.success(t("user-settings:update-success"));
 		},
 		onError: (error) => {
-			toast.error(
-				typeof error === "string"
-					? error
-					: error instanceof Error
-						? error.message
-						: t("user-settings:update-error"),
-			);
+			toast.error(getErrorMessage(error, t));
 		},
 		onSettled: () => setIsSaving(false),
 	});

--- a/src/app/admin/AdminSidebar.tsx
+++ b/src/app/admin/AdminSidebar.tsx
@@ -44,8 +44,9 @@ import {
 import { useTranslation } from "react-i18next";
 import Link from "next/link";
 import type { ForwardRefExoticComponent, RefAttributes } from "react";
-import { useAuthState, type RequiredPermission } from "@/lib/auth";
+import { usePermissionsState, type RequiredPermission } from "@/lib/auth";
 import { ActionEnum, TargetEnum } from "@/api";
+import { Skeleton } from "@/components/ui/skeleton";
 
 type AdminSidebarEntry = {
 	title: string;
@@ -229,20 +230,42 @@ const groups: AdminGroup[] = [
 
 export function AdminSidebar() {
 	const { t } = useTranslation();
-	const permissions = useAuthState().getPermissions();
+	const { permissions, isLoading, isError } = usePermissionsState();
 
-	// Filter out groups and entries the user doesn't have permission to see
-	const visibleGroups = groups
-		.map((group) => {
-			return {
-				...group,
-				// Also filter out entries
-				entries: group.entries.filter((item) =>
-					permissions.hasRequiredPermissions(item.permissions ?? []),
-				),
-			};
-		})
-		.filter((group) => group.entries.length > 0);
+	if (isLoading) {
+		return (
+			<Sidebar className="text-foreground ">
+				<SidebarHeader className="px-6 py-4 decoration-3 items-center bg-[#fa7909]">
+					<h2 className="text-2xl mt-2 transition-colors">
+						{t("admin:title")}
+					</h2>
+				</SidebarHeader>
+				<SidebarContent className="px-2 gap-2 bg-[#fa7909]">
+					<div className="px-3 py-2 space-y-3">
+						<Skeleton className="h-4 w-full bg-white/30" />
+						<Skeleton className="h-9 w-full bg-white/25" />
+						<Skeleton className="h-9 w-full bg-white/25" />
+						<Skeleton className="h-9 w-full bg-white/25" />
+					</div>
+				</SidebarContent>
+			</Sidebar>
+		);
+	}
+
+	// Filter out groups and entries the user doesn't have permission to see.
+	// On permission fetch errors we fail closed and show no admin entries.
+	const visibleGroups = isError
+		? []
+		: groups
+				.map((group) => {
+					return {
+						...group,
+						entries: group.entries.filter((item) =>
+							permissions.hasRequiredPermissions(item.permissions ?? []),
+						),
+					};
+				})
+				.filter((group) => group.entries.length > 0);
 
 	return (
 		<Sidebar className="text-foreground ">

--- a/src/app/admin/members/MemberEditForm.tsx
+++ b/src/app/admin/members/MemberEditForm.tsx
@@ -21,7 +21,7 @@ import { toast } from "sonner";
 import { AdminChooseMultPosts } from "@/widgets/AdminChooseMultPosts";
 import { Pen, Save } from "lucide-react";
 import UserDetailsCard from "@/components/UserDetailsCard";
-import { useAuthState } from "@/lib/auth";
+import { usePermissions } from "@/lib/auth";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -73,8 +73,7 @@ export default function UserPostsEditForm({
 	const { t } = useTranslation("admin");
 	const [confirmOpen, setConfirmOpen] = useState(false);
 	const [isEditing, setIsEditing] = useState(false);
-	const auth = useAuthState();
-	const permissions = auth.getPermissions();
+	const permissions = usePermissions();
 	const queryClient = useQueryClient();
 
 	const form = useForm<UserUpdate>({

--- a/src/app/admin/members/page.tsx
+++ b/src/app/admin/members/page.tsx
@@ -37,7 +37,7 @@ import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { LoadingErrorCard } from "@/components/LoadingErrorCard";
-import { useAuthState, type RequiredPermission } from "@/lib/auth";
+import { usePermissions, type RequiredPermission } from "@/lib/auth";
 import { ActionEnum, TargetEnum } from "@/api";
 import MemberEditForm from "./MemberEditForm";
 
@@ -53,7 +53,7 @@ export default function MembersPage() {
 	} = useQuery({
 		...adminGetAllUsersOptions(),
 	});
-	const permissions = useAuthState().getPermissions();
+	const permissions = usePermissions();
 	const hasManageUserPerms = permissions.hasRequiredPermissions([
 		[ActionEnum.MANAGE, TargetEnum.USER],
 	] as RequiredPermission[]);

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -15,7 +15,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { useAuthState } from "@/lib/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
@@ -32,6 +32,7 @@ const emailPasswordSchema = z.object({
 export default function LoginForm() {
 	const { t } = useTranslation();
 	const router = useRouter();
+	const queryClient = useQueryClient();
 	const searchParams = useSearchParams();
 	const [submitEnabled, setSubmitEnabled] = useState(true);
 	const auth = useAuthState();
@@ -66,9 +67,10 @@ export default function LoginForm() {
 		},
 		onSuccess: (data) => {
 			auth.setAccessToken(data);
+			queryClient.clear(); // After logging in, we want fresh data
 			const next = searchParams.get("next") || "/home";
 			router.push(next);
-			// Set a cookie to indicate the user is not authenticated, just for the middleware to check if it should redirect
+			// Set a cookie to indicate the user is now authenticated, just for the middleware to check if it should redirect
 			// obviously this is not secure enough for real authentication
 			const expires = new Date();
 			expires.setFullYear(expires.getFullYear() + 1);

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -28,6 +28,7 @@ import {
 	type DefaultError,
 	useMutation,
 	useQuery,
+	useQueryClient,
 } from "@tanstack/react-query";
 import {
 	getMeOptions,
@@ -71,6 +72,7 @@ export function NavBar() {
 		...getMeOptions(),
 		refetchOnWindowFocus: false,
 	});
+	const queryClient = useQueryClient();
 	const loginHandler = useLoginHandler();
 	const logoutMutation = useMutation({
 		...authCookieLogoutMutation({ credentials: "include" }),
@@ -79,6 +81,7 @@ export function NavBar() {
 			// obviously this is not secure enough for real authentication
 			document.cookie =
 				"auth_status=unauthenticated; path=/; SameSite=Strict; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+			queryClient.clear();
 			router.push("/");
 		},
 		onError: (error: DefaultError) => {

--- a/src/components/PermissionWall.tsx
+++ b/src/components/PermissionWall.tsx
@@ -1,37 +1,39 @@
 "use client";
 
-import { useAuthState, type RequiredPermission } from "@/lib/auth";
+import { usePermissionsState, type RequiredPermission } from "@/lib/auth";
 import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
+import { LoadingErrorCard } from "@/components/LoadingErrorCard";
 import Obfuscate from "react-obfuscate";
 
 function PermissionDenied() {
 	const { t } = useTranslation("main");
 	const router = useRouter();
+
 	return (
 		<div className="flex items-center justify-center min-h-screen bg-background text-foreground">
 			<section className="text-center">
-				<h1 className="mb-4 text-7xl font-extrabold tracking-tight lg:text-9xl text-destructive">
+				<div className="mb-4 text-7xl font-extrabold tracking-tight lg:text-9xl text-destructive">
 					{t("permission-wall.stop")}
-				</h1>
-				<p className="mb-4 text-3xl font-bold md:text-4xl">
+				</div>
+				<div className="mb-4 text-3xl font-bold md:text-4xl">
 					{t("permission-wall.subtitle")}
-				</p>
-				<p className="mb-4 text-lg font-light text-muted-foreground">
+				</div>
+				<div className="mb-4 text-lg font-light text-muted-foreground">
 					{t("permission-wall.message")}
 					<Obfuscate email={"spindelman@fsektionen.se"}>
-						<p className="inline-flex text-forange hover:bg-primary hover:text-white">
+						<div className="inline-flex text-forange hover:bg-primary hover:text-white">
 							{t("permission-wall.contact")}
-						</p>
+						</div>
 					</Obfuscate>
 					.
-				</p>
-				<p className="mb-4 text-lg font-light text-muted-foreground">
+				</div>
+				<div className="mb-4 text-lg font-light text-muted-foreground">
 					<i>{t("permission-wall.quote")}</i> -{" "}
 					{t("permission-wall.quote_author")}
-				</p>
+				</div>
 				<Button
 					type="button"
 					onClick={() => router.back()}
@@ -53,8 +55,23 @@ export default function PermissionWall({
 	mustHave?: "any" | "all";
 	children: ReactNode;
 }) {
-	const auth = useAuthState();
-	const perm = auth.getPermissions();
+	const {
+		permissions: perm,
+		isLoading,
+		isError,
+		error,
+	} = usePermissionsState();
+
+	if (isLoading) {
+		return <LoadingErrorCard />;
+	}
+
+	if (isError) {
+		const errorMessage =
+			error instanceof Error ? error : "Failed to load permissions";
+		return <LoadingErrorCard error={errorMessage} isLoading={false} />;
+	}
+
 	let allowed = false;
 	if (mustHave === "all") {
 		allowed = perm.hasRequiredPermissions(requiredPermissions);
@@ -66,5 +83,5 @@ export default function PermissionWall({
 	if (allowed) {
 		return <>{children}</>;
 	}
-	return PermissionDenied();
+	return <PermissionDenied />;
 }

--- a/src/components/PermissionWall.tsx
+++ b/src/components/PermissionWall.tsx
@@ -24,9 +24,9 @@ function PermissionDenied() {
 				<div className="mb-4 text-lg font-light text-muted-foreground">
 					{t("permission-wall.message")}
 					<Obfuscate email={"spindelman@fsektionen.se"}>
-						<div className="inline-flex text-forange hover:bg-primary hover:text-white">
+						<span className="inline-flex text-forange hover:bg-primary hover:text-white">
 							{t("permission-wall.contact")}
-						</div>
+						</span>
 					</Obfuscate>
 					.
 				</div>

--- a/src/components/PermissionWall.tsx
+++ b/src/components/PermissionWall.tsx
@@ -55,23 +55,19 @@ export default function PermissionWall({
 	mustHave?: "any" | "all";
 	children: ReactNode;
 }) {
-	const { t } = useTranslation("main");
-	const {
-		permissions: perm,
-		isLoading,
-		isError,
-		error,
-	} = usePermissionsState();
+	const permissionsState = usePermissionsState();
 
-	if (isLoading) {
+	if (permissionsState.isPending) {
 		return <LoadingErrorCard />;
 	}
 
-	if (isError) {
-		const errorMessage =
-			error instanceof Error ? error : t("permission-wall.error");
-		return <LoadingErrorCard error={errorMessage} isLoading={false} />;
+	if (permissionsState.isError) {
+		return (
+			<LoadingErrorCard error={permissionsState.error} isLoading={false} />
+		);
 	}
+
+	const perm = permissionsState.permissions;
 
 	let allowed = false;
 	if (mustHave === "all") {

--- a/src/components/PermissionWall.tsx
+++ b/src/components/PermissionWall.tsx
@@ -15,12 +15,12 @@ function PermissionDenied() {
 	return (
 		<div className="flex items-center justify-center min-h-screen bg-background text-foreground">
 			<section className="text-center">
-				<div className="mb-4 text-7xl font-extrabold tracking-tight lg:text-9xl text-destructive">
+				<h1 className="mb-4 text-7xl font-extrabold tracking-tight lg:text-9xl text-destructive">
 					{t("permission-wall.stop")}
-				</div>
-				<div className="mb-4 text-3xl font-bold md:text-4xl">
+				</h1>
+				<p className="mb-4 text-3xl font-bold md:text-4xl">
 					{t("permission-wall.subtitle")}
-				</div>
+				</p>
 				<div className="mb-4 text-lg font-light text-muted-foreground">
 					{t("permission-wall.message")}
 					<Obfuscate email={"spindelman@fsektionen.se"}>
@@ -30,10 +30,10 @@ function PermissionDenied() {
 					</Obfuscate>
 					.
 				</div>
-				<div className="mb-4 text-lg font-light text-muted-foreground">
+				<p className="mb-4 text-lg font-light text-muted-foreground">
 					<i>{t("permission-wall.quote")}</i> -{" "}
 					{t("permission-wall.quote_author")}
-				</div>
+				</p>
 				<Button
 					type="button"
 					onClick={() => router.back()}

--- a/src/components/PermissionWall.tsx
+++ b/src/components/PermissionWall.tsx
@@ -55,6 +55,7 @@ export default function PermissionWall({
 	mustHave?: "any" | "all";
 	children: ReactNode;
 }) {
+	const { t } = useTranslation("main");
 	const {
 		permissions: perm,
 		isLoading,
@@ -68,7 +69,7 @@ export default function PermissionWall({
 
 	if (isError) {
 		const errorMessage =
-			error instanceof Error ? error : "Failed to load permissions";
+			error instanceof Error ? error : t("permission-wall.error");
 		return <LoadingErrorCard error={errorMessage} isLoading={false} />;
 	}
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,10 +1,20 @@
 "use client";
 
+import { getMyPermissionsOptions } from "@/api/@tanstack/react-query.gen";
 import type { BearerResponse } from "@/api";
 import type { ActionEnum, TargetEnum } from "@/api";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { create } from "zustand";
 
 export type RequiredPermission = [ActionEnum, TargetEnum];
+export type UsePermissionsState = {
+	permissions: PermissionMap;
+	isLoading: boolean;
+	isError: boolean;
+	error: unknown;
+};
+
 class PermissionMap extends Map<TargetEnum, Set<ActionEnum>> {
 	/**
 	 * Checks a users permission against a list of required permissions.
@@ -15,9 +25,8 @@ class PermissionMap extends Map<TargetEnum, Set<ActionEnum>> {
 	 * Checking that a user has `view` permission for `CAR` and `manage` permission for `USER`
 	 * ```ts
 	 * import type { ActionEnum, TargetEnum } from "@/api";
-	 * import { useAuthState } from "@/lib/auth";
-	 * const auth = useAuthState();
-	 * const permissions = auth.getPermissions();
+	 * import { usePermissions } from "@/lib/auth";
+	 * const permissions = usePermissions();
 	 * const isAllowed = permissions.hasRequiredPermissions([[ActionEnum.VIEW, TargetEnum.CAR], [ActionEnum.MANAGE, TargetEnum.USER]]);
 	 * ```
 	 */
@@ -37,48 +46,50 @@ type AuthState = {
 	setAccessToken: (data: BearerResponse) => void;
 	authorizationHeader: () => string | null;
 	isAuthenticated: () => boolean;
-	getPermissions: () => PermissionMap;
 };
 
-export const useAuthState = create<AuthState>((set, get) => {
-	let permissionMap = new PermissionMap();
+function buildPermissionMap(
+	permissions: [string, string][] | null | undefined,
+): PermissionMap {
+	const map = new PermissionMap();
+	if (!permissions) return map;
 
-	function buildPermissionMap(token: BearerResponse | null): PermissionMap {
-		const map = new PermissionMap();
-		if (!token) return map;
-		try {
-			const payload = JSON.parse(
-				Buffer.from(token.access_token.split(".")[1], "base64").toString(),
-			) as { permissions: string[] };
+	for (const [actionStr, targetStr] of permissions) {
+		const actionEnum = actionStr as ActionEnum;
+		const targetEnum = targetStr as TargetEnum;
 
-			for (const entry of payload.permissions) {
-				const parts = entry.split(":");
-				if (parts.length !== 2) continue;
+		if (!actionEnum || !targetEnum) continue;
 
-				const [actionStr, targetStr] = parts;
-
-				const actionEnum = actionStr as ActionEnum;
-				const targetEnum = targetStr as TargetEnum;
-
-				if (!actionEnum || !targetEnum) continue;
-
-				if (!map.has(targetEnum)) {
-					map.set(targetEnum, new Set<ActionEnum>());
-				}
-				// biome-ignore lint/style/noNonNullAssertion: Just checked that it exists
-				map.get(targetEnum)!.add(actionEnum);
-			}
-		} catch {
-			// If decoding or parsing fails, just return an empty map
+		if (!map.has(targetEnum)) {
+			map.set(targetEnum, new Set<ActionEnum>());
 		}
-
-		return map;
+		// biome-ignore lint/style/noNonNullAssertion: Just checked that it exists
+		map.get(targetEnum)!.add(actionEnum);
 	}
 
-	function updatePermissions(token: BearerResponse | null) {
-		permissionMap = buildPermissionMap(token);
-	}
+	return map;
+}
 
+export function usePermissions(): PermissionMap {
+	return usePermissionsState().permissions;
+}
+
+export function usePermissionsState(): UsePermissionsState {
+	const { data, isLoading, isError, error } = useQuery({
+		...getMyPermissionsOptions(),
+		staleTime: 60 * 1000,
+	});
+	const permissions = useMemo(() => buildPermissionMap(data), [data]);
+
+	return {
+		permissions,
+		isLoading,
+		isError,
+		error,
+	};
+}
+
+export const useAuthState = create<AuthState>((set, get) => {
 	return {
 		accessToken: null,
 		setAccessToken(data) {
@@ -86,7 +97,6 @@ export const useAuthState = create<AuthState>((set, get) => {
 				if (state.accessToken?.access_token === data.access_token) {
 					return { accessToken: data };
 				}
-				updatePermissions(data);
 				return { accessToken: data };
 			});
 		},
@@ -113,9 +123,6 @@ export const useAuthState = create<AuthState>((set, get) => {
 		},
 		isAuthenticated() {
 			return !!get().authorizationHeader();
-		},
-		getPermissions() {
-			return permissionMap;
 		},
 	};
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -8,14 +8,8 @@ import { useMemo } from "react";
 import { create } from "zustand";
 
 export type RequiredPermission = [ActionEnum, TargetEnum];
-export type UsePermissionsState = {
-	permissions: PermissionMap;
-	isLoading: boolean;
-	isError: boolean;
-	error: unknown;
-};
 
-class PermissionMap extends Map<TargetEnum, Set<ActionEnum>> {
+export class PermissionMap extends Map<TargetEnum, Set<ActionEnum>> {
 	/**
 	 * Checks a users permission against a list of required permissions.
 	 *
@@ -74,20 +68,20 @@ export function usePermissions(): PermissionMap {
 	return usePermissionsState().permissions;
 }
 
-export function usePermissionsState(): UsePermissionsState {
-	const { data, isLoading, isError, error } = useQuery({
+export function usePermissionsState() {
+	const query = useQuery({
 		...getMyPermissionsOptions(),
 		staleTime: 60 * 1000,
 	});
-	const permissions = useMemo(() => buildPermissionMap(data), [data]);
+	const permissions = useMemo(
+		() => buildPermissionMap(query.data),
+		[query.data],
+	);
 
-	return {
-		permissions,
-		isLoading,
-		isError,
-		error,
-	};
+	return { ...query, permissions };
 }
+
+export type UsePermissionsState = ReturnType<typeof usePermissionsState>;
 
 export const useAuthState = create<AuthState>((set, get) => {
 	return {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -93,12 +93,7 @@ export const useAuthState = create<AuthState>((set, get) => {
 	return {
 		accessToken: null,
 		setAccessToken(data) {
-			set((state) => {
-				if (state.accessToken?.access_token === data.access_token) {
-					return { accessToken: data };
-				}
-				return { accessToken: data };
-			});
+			set({ accessToken: data });
 		},
 		authorizationHeader() {
 			const accessToken = get().accessToken;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -52,7 +52,12 @@ function buildPermissionMap(
 		const actionEnum = actionStr as ActionEnum;
 		const targetEnum = targetStr as TargetEnum;
 
-		if (!actionEnum || !targetEnum) continue;
+		if (!actionEnum || !targetEnum) {
+			console.warn(
+				`Unknown permission from backend: ${actionStr}:${targetStr}`,
+			);
+			continue;
+		}
 
 		if (!map.has(targetEnum)) {
 			map.set(targetEnum, new Set<ActionEnum>());

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1,502 +1,502 @@
 {
-	"fsek": "F-Guild",
-	"title": "Main Page",
-	"calendar": "Calendar",
-	"calendarText": "Here you can see the guild's calendar with upcoming events. Click to go to the full calendar page and then scroll down for information on how to add our events to your own calendar app.",
-	"welcome": "Welcome to the new F-Guild website!",
-	"welcomeText": "We are currently in a transition period to our new website. We are continuously working to improve the design and functionality, and add things that are currently missing compared to the old website. By the way, it can still be used at old.fsektionen.se. Since we have also replaced the server and the database, the new and old systems are separated: if you have old accounts, room bookings, settings, car bookings, etc. they will not be available through the new web and you will have to make new ones. NOTE! We plan to get rid of the old website in the near future, so please try to use the new one as much as possible. If you have any questions or comments, please do not hesitate to contact the webmasters via spindelman@fsektionen.se.",
-	"oldWebsiteButton": "Take me back to the old site...",
-	"welcomeAdmin": "If you think you should have some sort of admin access, try clicking the button below, in the navbar or going to fsektionen.se/admin. If you still don't have access, please contact the head of your council (council boss).",
-	"adminButton": "Admin Page",
-	"registerButton": "Register a new account",
-	"newsTitle": "News",
-	"newsText": "If you want to use more advanced formatting, use Mattermost until we have added more options. The news page now supports images!",
-	"cafeTitle": "Hilbert Cafe",
-	"cafeText": "Hilbert Cafe is a place for students to meet, study and socialize. Here you will eventually find more interactive information about the cafe, its opening hours and staff. The café also has its own page, and you can now sign up for café shifts on a separate page.",
-	"cafe_shift_button": "Sign up for a shift",
-	"cafe_page_button": "Main cafe page",
-	"coolThing": "A cool thing that distracts you from seeing that the page is not finished yet",
-	"back": "Back",
-	"faq": {
-		"self": "Questions answered",
-		"q1": {
-			"question": "Can I log in with my old account?",
-			"answer": "No, since we switched to a new database you need to create a new account. You can do that at fsektionen.se/register. There are many things you won't have access to until you create an account, verify your email, and become verified as a member."
-		},
-		"q2": {
-			"question": "How do I become verified as a member?",
-			"answer": "Create an account, verify your email, and add your Stil-ID (hi6122mo-s) in the user settings (check the top right corner). After this, you must wait for us to verify that you are indeed a member. At the start of the semester, this may take longer than usual. If you feel that it is taking too long, you can contact your council boss or a mentor/föset during the introduction period."
-		},
-		"q3": {
-			"question": "What do you still have left to move over?",
-			"answer": "Most things are now available. To read the governing documents in their entirety (though they are available in the document archive if you know their names) or use the proposition machine (RIP), you can use the old website. We are working as diligently as possible to ensure that everything is available on the new website. 🧡"
-		},
-		"q4": {
-			"question": "Help! I don't have any of my old admin rights!",
-			"answer": "Please wait or contact your council boss and ask them to give you the appropriate permissions."
-		},
-		"q5": {
-			"question": "I am having problems signing up to events, viewing the gallery, or other things!??",
-			"answer": "We prevent non-members and users without verified email addresses from using many of our services. Check the following: \n\nThat you really have verified your account (try fsektionen.se/verify). \nThat you are registered as a member. (look in account settings to check for both of these!) \nThat you are logged in to the correct account and have not created multiple accounts, for example one with your student email and another with your personal email. If you have more than one account and want to get rid of the bad one, contact spindelman@fsektionen.se via the email of the account you want to delete."
-		}
-	},
-	"next": "Next",
-	"previous": "Previous",
-	"page": "Page",
-	"navbar": {
-		"sektionen": {
-			"self": "The Guild",
-			"about": {
-				"self": "About Us",
-				"desc": "Welcome to our community - discover our story and values.",
-				"href": "/about"
-			},
-			"news": {
-				"self": "News",
-				"desc": "Stay up-to-date with the latest announcements.",
-				"href": "/news"
-			},
-			"calendar": {
-				"self": "Calendar",
-				"desc": "Keep track of upcoming events and activities.",
-				"href": "/calendar"
-			},
-			"councils": {
-				"self": "Councils",
-				"desc": "Get to know the teams that together form the F-Guild.",
-				"href": "/councils"
-			},
-			"documents": {
-				"self": "Documents",
-				"desc": "Here you can find all the fine documents that have been produced.",
-				"href": "/documents"
-			},
-			"privacy": {
-				"self": "Privacy Policy",
-				"desc": "Learn more about how we handle your personal data.",
-				"href": "/privacy"
-			},
-			"nollning": {
-				"self": "The Introduction",
-				"desc": "Welcome to the F-guild and congratulations on your spot on the engineering program in engineering physics, engineering mathematics, or engineering nanoscience!",
-				"href": "/nollning"
-			}
-		},
-		"engage": {
-			"self": "Get Involved",
-			"cafe": {
-				"self": "Hilbert Cafe",
-				"desc": "Meet like-minded people and enjoy the relaxing atmosphere at the café (and free lunch!).",
-				"href": "/cafe"
-			},
-			"positions": {
-				"self": "Become a Volunteer!",
-				"desc": "Want to get involved? Look here!",
-				"href": "/positions"
-			},
-			"nollningsvol": {
-				"self": "Intro-week Volunteering",
-				"desc": "Help us welcome new students and give them a great start to their studies!",
-				"href": "/nollningsvolontar"
-			},
-			"elections": {
-				"self": "Elections",
-				"desc": "Apply for the guild's positions.",
-				"href": "/election"
-			},
-			"projects": {
-				"self": "Projects",
-				"desc": "Discover innovative initiatives and collaborative efforts.",
-				"href": "/projects"
-			},
-			"freja": {
-				"self": "FREJA",
-				"desc": "FREJA is an independent organization for women or non-binary students.",
-				"href": "https://www.frejalth.se/"
-			}
-		},
-		"services": {
-			"self": "Services",
-			"car": {
-				"self": "Car Rentals",
-				"desc": "Book the guild vehicle for your travel and daily needs.",
-				"href": "/car"
-			},
-			"rooms": {
-				"self": "Room Bookings",
-				"desc": "Book the three rooms in the Mathematics building for personal events or guild meetings.",
-				"href": "/room-bookings"
-			},
-			"tools": {
-				"self": "Tool Library",
-				"desc": "Borrow the guild's high-quality tools to help bring your projects to life.",
-				"href": "/tools"
-			},
-			"specialrooms": {
-				"self": "Quiet/Prayer Rooms",
-				"desc": "Find a peaceful space for reflection or private prayer.",
-				"href": "/stillarum"
-			},
-			"gallery": {
-				"self": "Gallery",
-				"desc": "Explore our photo gallery and get a glimpse into the guild's history.",
-				"href": "/gallery"
-			},
-			"calendar": {
-				"self": "Calendar",
-				"desc": "Keep track of upcoming events and activities.",
-				"href": "/calendar"
-			},
-			"songs": {
-				"self": "Songs",
-				"desc": "Browse the songs heard and sung at the guild's events.",
-				"href": "/songs"
-			}
-		},
-		"companies": {
-			"self": "Companies",
-			"aboutCompany": {
-				"self": "About Us",
-				"desc": "Discover who we are and what programs we represent.",
-				"href": "/foretag/om"
-			},
-			"offerings": {
-				"self": "Our Offerings",
-				"desc": "Explore proposals for ways to cooperate to reach our members.",
-				"href": "/foretag/vi-erbjuder"
-			},
-			"farad": {
-				"self": "Farad",
-				"desc": "Read about the job fair for the F-Guild.",
-				"href": "https://farad.nu"
-			},
-			"contact": {
-				"self": "Business Contact",
-				"desc": "Reach out to us for partnership and business inquiries.",
-				"href": "/contact#naringslivsutskottet"
-			}
-		},
-		"contact": {
-			"self": "Contact",
-			"contactPage": {
-				"self": "Contact Page",
-				"desc": "Find all the information you need to get in touch with us.",
-				"href": "/contact"
-			},
-			"ordf": {
-				"self": "President",
-				"desc": "For questions about the organisation.",
-				"href": "/contact#ordf"
-			},
-			"web": {
-				"self": "Webmaster",
-				"desc": "For questions about the website or app.",
-				"href": "/contact#webmaster"
-			},
-			"anonymousForm": {
-				"self": "Anonymous Contact",
-				"desc": "Share your feedback or concerns confidentially.",
-				"href": "https://docs.google.com/forms/d/e/1FAIpQLSdZdPl14DkdlZCKS3jzO59-FvVi2ug9nYer1jhYgERanbwHoQ/viewform"
-			},
-			"klaga": {
-				"self": "Complaint",
-				"desc": "Send an anonymous complaint, opinion or report to TLTH.",
-				"href": "https://www.tlth.se/klaga"
-			}
-		},
-		"booking": "Bookings",
-		"documents": "Documents",
-		"account-settings": "Account Settings",
-		"logout": "Log out",
-		"logoutError": "Logout failed. Please try again later.",
-		"verify": "Verify Email",
-		"guild-meeting": "Guild Meeting"
-	},
-	"footer": {
-		"contact": "Contact",
-		"emergencycontact": "Emergency Contact",
-		"companies": "For Companies",
-		"webansvar": "Webmaster",
-		"ansvar": "Publisher",
-		"copyright": "F-Guild. All rights reserved in superposition in an impenetrable box."
-	},
-	"login": {
-		"login": "Log in",
-		"invalid-email-or-password": "Invalid email address or password",
-		"email": "Email",
-		"password": "Password",
-		"title": "Log in",
-		"registerPrompt": "Don't have an account? Register here.",
-		"forgotPassword": "Forgot password?",
-		"forgotEmailLabel": "Enter your email to reset password",
-		"forgotSubmit": "Send reset link",
-		"forgotLoading": "Sending...",
-		"forgotSuccess": "If your email exists, a reset link has been sent.",
-		"backToLogin": "Back to login",
-		"invalidEmailFormat": "Invalid email format"
-	},
-	"news": {
-		"self": "News",
-		"by": "Written by: ",
-		"pinned": "Pinned",
-		"see_all": "See all news",
-		"read_more": "Read more"
-	},
-	"verifyMail": {
-		"loading": "Verifying your email...",
-		"success": "Email verification succeeded!",
-		"error": "Email verification failed. The link may have expired or been invalid, or you may have already verified your email. You can go to fsektionen.se/verify with no token to get a new link.",
-		"goHome": "Go to the homepage",
-		"noToken": "You can request a new verification link by entering your email below. (if you came here from an email, check that you copied the entire link.)",
-		"requestSuccess": "A verification link has been sent to your email address if it is registered.",
-		"requestError": "Failed to send verification email. Please try again later.",
-		"emailPlaceholder": "Enter your email",
-		"requestNew": "Request New Verification Email"
-	},
-	"verifyReminder": {
-		"message": "Your account does not have a verified email. You MUST verify your email before the website will function properly.",
-		"go": "Verify Now"
-	},
-	"memberBanner": {
-		"message": "Your account is not registered as a member of the F-guild. You cannot do anything about this yourself. Contact your council chairperson or another admin within the guild to be registered as a member. Until then, you will not be able to use many of the guild's services."
-	},
-	"reset-password": {
-		"title": "Reset Password",
-		"password": "New Password",
-		"retype-password": "Retype password",
-		"passwords-do-not-match": "Passwords do not match",
-		"reset-password": "Reset Password",
-		"resetting": "Resetting your password...",
-		"reset-success": "Your password has been reset successfully!",
-		"goHome": "Go to Home",
-		"reset-error": "Password reset failed.",
-		"invalid-reset-token": "Invalid or missing reset token."
-	},
-	"register": {
-		"title": "Register for an Account",
-		"email": "Email",
-		"password": "Password",
-		"confirmPassword": "Confirm Password",
-		"firstName": "First Name",
-		"lastName": "Last Name",
-		"telephone": "Telephone Number with country code (+46)",
-		"startYear": "Start Year (optional)",
-		"submit": "Register",
-		"loginPrompt": "Already have an account? Login here.",
-		"loading": "Registering...",
-		"error": "Registration failed. Please check your details and try again.",
-		"verifyError": "Registered user, but failed to send verification email. Please try again later.",
-		"success": "Registration successful! Please check your email to verify your account.",
-		"goLogin": "Go to Login",
-		"passwordMismatch": "Passwords do not match. Please try again.",
-		"passwordNoNumber": "Password must contain at least one number.",
-		"passwordNoLetter": "Password must contain at least one english letter.",
-		"startYearInvalid": "Start year must be between 1960 and the current year.",
-		"emailInvalid": "Invalid email address",
-		"passwordShort": "Password must be at least 8 characters",
-		"firstNameRequired": "First name required",
-		"lastNameRequired": "Last name required",
-		"telephoneNumberRequired": "Telephone number required",
-		"gdprLabel": "I have read and agree to the",
-		"privacyPolicy": "privacy policy.",
-		"gdprRequired": "You must agree to the privacy policy to register."
-	},
-	"car-booking": {
-		"title": "Car Booking",
-		"description-title": "FAQ and rules",
-		"description": "As a member, you can book the guild car for your personal and guild-related needs. If you are an admin, you can manage bookings <0>here</0> instead. By booking the car, you agree to follow the rules found <1>here</1>.",
-		"faq": {
-			"title": "Frequently Asked Questions",
-			"q1": "Who can book the car?",
-			"a1": "Any member of the guild can book the car.",
-			"q2": "Car renting during the summer?",
-			"a2": "As activities are suspended during the summer, it is not easy to rent the guild's car. Contact the board (at) fsektionen.se to ask if it can be solved.",
-			"q3": "How many people can fit in the car?",
-			"a3": "The car can accommodate up to 7 people, including the driver.",
-			"q4": "What is the cargo capacity of the car?",
-			"a4": "The trunk (with the rear seats folded) is approximately (with the reservation that it is not a perfect rectangle) 190 cm deep, 130 cm wide and 80 cm high.",
-			"q5": "How much does it cost to rent the car?",
-			"a5": "Members of the F-guild pay a starting fee of SEK 150. The starting fee includes 20 kilometers, after that it costs SEK 5 per kilometer started.",
-			"q6": "What do the colors mean?",
-			"a6": "Different colors show status and ownership for each booking. An admin (the car foreman) must confirm bookings outside regular hours. The colors have the following meaning:\n- Light orange color means it's your booking, but it's not confirmed.\n- Dark orange color means it's your booking and it's confirmed.\n- Green color marks someone else's confirmed booking.\n- Yellow color shows someone else's unconfirmed booking.\n- Light blue color is used for bookings that have been added locally but haven't been retrieved from the server yet. If you see blue, something may have gone wrong, reload the page manually.",
-			"q7": "I have more questions!",
-			"a7": "You can contact the car foreman through, among other ways, the <0>contact page</0>. Please ask the car foreman or a webmaster to add the question with an answer here."
-		}
-	},
-	"room-booking": {
-		"title": "Room Bookings",
-		"description-title": "FAQ and rules",
-		"description": "As a member, you must ask an admin if you want to book a room, but you can view all room bookings here. If you are an admin, you can book rooms <0>here</0> instead.",
-		"faq": {
-			"title": "Frequently Asked Questions",
-			"q1": "Who can book the rooms?",
-			"a1": "Only admins can book the rooms. If you are a member, you can contact an admin from nämnden to ask them to book a room.",
-			"q2": "I have more questions!",
-			"a2": "There is no guild executive who is solely responsible for the room bookings. Contact the equipment master or the board if you have any questions. You can also ask them to add the question with an answer here."
-		}
-	},
-	"loading": {
-		"basic": "Loading content...",
-		"flavor_1": "Checking into Hilbert's hotel...",
-		"flavor_2": "Finding the determinant...",
-		"flavor_3": "Playing moose game...",
-		"flavor_4": "Calculating the last digit of π...",
-		"flavor_5": "Fermenting more Hilbeaux...",
-		"flavor_6": "Polishing pixels...",
-		"flavor_7": "Counting to infinity...",
-		"flavor_8": "Creating yet another Gandalf-exam...",
-		"flavor_9": "Proving the Riemann hypothesis...",
-		"flavor_10": "Changing coordinate systems...",
-		"flavor_11": "Preparing Hilbert sandwiches...",
-		"flavor_12": "Waiting for Ladok notification...",
-		"flavor_13": "Waiting for the impulse response to fade out...",
-		"flavor_14": "Responding to motion...",
-		"flavor_15": "Compiling LaTeX...",
-		"flavor_16": "Making boundary conditions homogeneous...",
-		"error_occurred": "Some error occurred:",
-		"no_error_message": "No error message available.",
-		"network_error": "Network error occurred. Please check your connection.",
-		"unauthorized": "You are not authorized to view this information. Please log in."
-	},
-	"cookieConsent": {
-		"message": "We use cookies to enhance your experience on our website (authentication, language and more). By continuing to use the site, you agree to our use of cookies.",
-		"accept": "Okay"
-	},
-	"permission-wall": {
-		"stop": "Stop",
-		"subtitle": "Slow down there!",
-		"message": "You do not have permission to view this page. If you believe this is an error, ",
-		"contact": "please contact your local webmaster.",
-		"quote": "You are not a subset of the set of all users with access to this page.",
-		"quote_author": "The wise Debianne server",
-		"button": "Back to homepage"
-	},
-	"documents": {
-		"title": "Title",
-		"created_at": "Created At",
-		"private_explanation": "Members only",
-		"author": "Author",
-		"category": "Category",
-		"view": "View",
-		"view_doc": "View Document",
-		"page_title": "Documents",
-		"description": "Here you can find and view documents shared within the guild. Some documents may be only visible to members.",
-		"search_title": "Search by title or category",
-		"is_private": "Only shown to members",
-		"updated_at": "Updated At",
-		"file_name": "File Name"
-	},
-	"guild_meeting": {
-		"important_dates": "Important Dates"
-	},
-	"yes": "Yes",
-	"no": "No",
-	"not_found": "Not found",
-	"description": "Description",
-	"event_signup": {
-		"title": "Event Signup",
-		"priority": "Priority",
-		"select_priority": "Select priority group to sign up as",
-		"group_name": "Group Name",
-		"group_name_placeholder": "Enter group name (optional)",
-		"drink_package": {
-			"title": "Drink Package",
-			"none": "None",
-			"alcohol_free": "Alcohol Free",
-			"alcohol": "Alcohol"
-		},
-		"select_drink_package": "Select drink package",
-		"button": "Sign up",
-		"update_button": "Update signup",
-		"edit_button": "Edit",
-		"signoff_button": "Sign off",
-		"success_create": "Signup successful!",
-		"success_update": "Signup updated!",
-		"success_signoff": "You have signed off from the event.",
-		"error_create": "Failed to sign up: {{error}}",
-		"error_update": "Failed to update signup: {{error}}",
-		"error_signoff": "Failed to sign off: {{error}}",
-		"unknown_error": "Unknown error.",
-		"not_found": "You are not signed up for this event.",
-		"user": "User",
-		"status": "Status",
-		"confirmed": "Confirmed",
-		"pending": "Pending",
-		"period_passed_signed_up": "Signup period has ended. If you want to change or withdraw your signup, please contact the event organizer.",
-		"period_passed_not_signed_up": "Signup period has ended. You can no longer sign up. If you have any questions, please contact the event organizer.",
-		"food_preferences_title": "Food Preferences",
-		"food_preferences_explainer": "These are your saved food preferences. If something doesn't look right, please update them in your account settings.",
-		"standard_food_preferences": "Standard preferences:",
-		"other_food_preferences": "Other preferences:",
-		"none": "None",
-		"signup_not_used": "You cannot sign up for this event as it does not use the system for signing up to attend."
-	},
-	"songs": {
-		"by": "By",
-		"melody": "Melody",
-		"category": "Category",
-		"views": "Views",
-		"title": "Songs",
-		"description_subtitle": "Browse and sing along with our collection of songs.",
-		"search_placeholder": "Search songs..."
-	},
-	"gallery": {
-		"title": "Gallery",
-		"select_year": "Select year",
-		"photographers": "Photographers"
-	},
-	"post": "Council Post",
-	"elections": {
-		"ended": "Ended",
-		"left": "left",
-		"day": "{{count}} day(s)",
-		"hour": "{{count}} hour(s)",
-		"min": "{{count}} min(s)",
-		"no_visible_election": "No visible election available",
-		"post_name": "Post Name",
-		"recommended_limit": "Recommended Limit",
-		"max_limit": "Max Limit",
-		"candidation_count": "Candidates",
-		"elected_by": "Elected By",
-		"council": "Council",
-		"end_time": "End Time",
-		"search_posts_placeholder": "Search posts...",
-		"no_posts_match": "No posts match your search",
-		"view_my_candidations": "View My Candidations",
-		"add_candidation": "Add Candidation",
-		"add_nomination": "Add Nomination",
-		"select_post": "Select post",
-		"candidation_error": "Failed to submit candidation",
-		"candidation_success": "Candidation submitted successfully!",
-		"nomination_error": "Failed to submit nomination",
-		"nomination_success": "Nomination submitted successfully!",
-		"nominee_name": "Nominee Name",
-		"nominee_email": "Nominee Email",
-		"motivation": "Motivation",
-		"election_limits": "Election Limits",
-		"ends_in": "Ends In",
-		"actions": "Actions",
-		"candidated_status": "Candidation Status",
-		"you_have_candidated": "You have candidated for this post",
-		"candidated_at": "Candidated at",
-		"remove_candidation": "Remove Candidation",
-		"elected_at_semester": "Elected At Semester",
-		"no_description": "No description available",
-		"my_candidations": {
-			"page_title": "My Candidations",
-			"page_description": "Here you can view and manage your election candidations"
-		},
-		"back_to_elections": "Back to Elections",
-		"no_candidations": "You have no candidations",
-		"delete_candidation_success": "Candidation deleted successfully",
-		"error_delete_candidation": "Failed to delete candidation",
-		"limits": "Limits",
-		"no_limit": "No limit",
-		"no_end_time": "No end time",
-		"election_table_description": "Here is a list of all posts open for nominations and candidations. The limits for how many people can be elected to each post are ordered by recommended limit first, followed by the max limit.",
-		"sub_election": "Election category"
-	},
-	"info_box": {
-		"title": "Details"
-	}
+  "fsek": "F-Guild",
+  "title": "Main Page",
+  "calendar": "Calendar",
+  "calendarText": "Here you can see the guild's calendar with upcoming events. Click to go to the full calendar page and then scroll down for information on how to add our events to your own calendar app.",
+  "welcome": "Welcome to the new F-Guild website!",
+  "welcomeText": "We are currently in a transition period to our new website. We are continuously working to improve the design and functionality, and add things that are currently missing compared to the old website. By the way, it can still be used at old.fsektionen.se. Since we have also replaced the server and the database, the new and old systems are separated: if you have old accounts, room bookings, settings, car bookings, etc. they will not be available through the new web and you will have to make new ones. NOTE! We plan to get rid of the old website in the near future, so please try to use the new one as much as possible. If you have any questions or comments, please do not hesitate to contact the webmasters via spindelman@fsektionen.se.",
+  "oldWebsiteButton": "Take me back to the old site...",
+  "welcomeAdmin": "If you think you should have some sort of admin access, try clicking the button below, in the navbar or going to fsektionen.se/admin. If you still don't have access, please contact the head of your council (council boss).",
+  "adminButton": "Admin Page",
+  "registerButton": "Register a new account",
+  "newsTitle": "News",
+  "newsText": "If you want to use more advanced formatting, use Mattermost until we have added more options. The news page now supports images!",
+  "cafeTitle": "Hilbert Cafe",
+  "cafeText": "Hilbert Cafe is a place for students to meet, study and socialize. Here you will eventually find more interactive information about the cafe, its opening hours and staff. The café also has its own page, and you can now sign up for café shifts on a separate page.",
+  "cafe_shift_button": "Sign up for a shift",
+  "cafe_page_button": "Main cafe page",
+  "coolThing": "A cool thing that distracts you from seeing that the page is not finished yet",
+  "back": "Back",
+  "faq": {
+    "self": "Questions answered",
+    "q1": {
+      "question": "Can I log in with my old account?",
+      "answer": "No, since we switched to a new database you need to create a new account. You can do that at fsektionen.se/register. There are many things you won't have access to until you create an account, verify your email, and become verified as a member."
+    },
+    "q2": {
+      "question": "How do I become verified as a member?",
+      "answer": "Create an account, verify your email, and add your Stil-ID (hi6122mo-s) in the user settings (check the top right corner). After this, you must wait for us to verify that you are indeed a member. At the start of the semester, this may take longer than usual. If you feel that it is taking too long, you can contact your council boss or a mentor/föset during the introduction period."
+    },
+    "q3": {
+      "question": "What do you still have left to move over?",
+      "answer": "Most things are now available. To read the governing documents in their entirety (though they are available in the document archive if you know their names) or use the proposition machine (RIP), you can use the old website. We are working as diligently as possible to ensure that everything is available on the new website. 🧡"
+    },
+    "q4": {
+      "question": "Help! I don't have any of my old admin rights!",
+      "answer": "Please wait or contact your council boss and ask them to give you the appropriate permissions."
+    },
+    "q5": {
+      "question": "I am having problems signing up to events, viewing the gallery, or other things!??",
+      "answer": "We prevent non-members and users without verified email addresses from using many of our services. Check the following: \n\nThat you really have verified your account (try fsektionen.se/verify). \nThat you are registered as a member. (look in account settings to check for both of these!) \nThat you are logged in to the correct account and have not created multiple accounts, for example one with your student email and another with your personal email. If you have more than one account and want to get rid of the bad one, contact spindelman@fsektionen.se via the email of the account you want to delete."
+    }
+  },
+  "next": "Next",
+  "previous": "Previous",
+  "page": "Page",
+  "navbar": {
+    "sektionen": {
+      "self": "The Guild",
+      "about": {
+        "self": "About Us",
+        "desc": "Welcome to our community - discover our story and values.",
+        "href": "/about"
+      },
+      "news": {
+        "self": "News",
+        "desc": "Stay up-to-date with the latest announcements.",
+        "href": "/news"
+      },
+      "calendar": {
+        "self": "Calendar",
+        "desc": "Keep track of upcoming events and activities.",
+        "href": "/calendar"
+      },
+      "councils": {
+        "self": "Councils",
+        "desc": "Get to know the teams that together form the F-Guild.",
+        "href": "/councils"
+      },
+      "documents": {
+        "self": "Documents",
+        "desc": "Here you can find all the fine documents that have been produced.",
+        "href": "/documents"
+      },
+      "privacy": {
+        "self": "Privacy Policy",
+        "desc": "Learn more about how we handle your personal data.",
+        "href": "/privacy"
+      },
+      "nollning": {
+        "self": "The Introduction",
+        "desc": "Welcome to the F-guild and congratulations on your spot on the engineering program in engineering physics, engineering mathematics, or engineering nanoscience!",
+        "href": "/nollning"
+      }
+    },
+    "engage": {
+      "self": "Get Involved",
+      "cafe": {
+        "self": "Hilbert Cafe",
+        "desc": "Meet like-minded people and enjoy the relaxing atmosphere at the café (and free lunch!).",
+        "href": "/cafe"
+      },
+      "positions": {
+        "self": "Become a Volunteer!",
+        "desc": "Want to get involved? Look here!",
+        "href": "/positions"
+      },
+      "nollningsvol": {
+        "self": "Intro-week Volunteering",
+        "desc": "Help us welcome new students and give them a great start to their studies!",
+        "href": "/nollningsvolontar"
+      },
+      "elections": {
+        "self": "Elections",
+        "desc": "Apply for the guild's positions.",
+        "href": "/election"
+      },
+      "projects": {
+        "self": "Projects",
+        "desc": "Discover innovative initiatives and collaborative efforts.",
+        "href": "/projects"
+      },
+      "freja": {
+        "self": "FREJA",
+        "desc": "FREJA is an independent organization for women or non-binary students.",
+        "href": "https://www.frejalth.se/"
+      }
+    },
+    "services": {
+      "self": "Services",
+      "car": {
+        "self": "Car Rentals",
+        "desc": "Book the guild vehicle for your travel and daily needs.",
+        "href": "/car"
+      },
+      "rooms": {
+        "self": "Room Bookings",
+        "desc": "Book the three rooms in the Mathematics building for personal events or guild meetings.",
+        "href": "/room-bookings"
+      },
+      "tools": {
+        "self": "Tool Library",
+        "desc": "Borrow the guild's high-quality tools to help bring your projects to life.",
+        "href": "/tools"
+      },
+      "specialrooms": {
+        "self": "Quiet/Prayer Rooms",
+        "desc": "Find a peaceful space for reflection or private prayer.",
+        "href": "/stillarum"
+      },
+      "gallery": {
+        "self": "Gallery",
+        "desc": "Explore our photo gallery and get a glimpse into the guild's history.",
+        "href": "/gallery"
+      },
+      "calendar": {
+        "self": "Calendar",
+        "desc": "Keep track of upcoming events and activities.",
+        "href": "/calendar"
+      },
+      "songs": {
+        "self": "Songs",
+        "desc": "Browse the songs heard and sung at the guild's events.",
+        "href": "/songs"
+      }
+    },
+    "companies": {
+      "self": "Companies",
+      "aboutCompany": {
+        "self": "About Us",
+        "desc": "Discover who we are and what programs we represent.",
+        "href": "/foretag/om"
+      },
+      "offerings": {
+        "self": "Our Offerings",
+        "desc": "Explore proposals for ways to cooperate to reach our members.",
+        "href": "/foretag/vi-erbjuder"
+      },
+      "farad": {
+        "self": "Farad",
+        "desc": "Read about the job fair for the F-Guild.",
+        "href": "https://farad.nu"
+      },
+      "contact": {
+        "self": "Business Contact",
+        "desc": "Reach out to us for partnership and business inquiries.",
+        "href": "/contact#naringslivsutskottet"
+      }
+    },
+    "contact": {
+      "self": "Contact",
+      "contactPage": {
+        "self": "Contact Page",
+        "desc": "Find all the information you need to get in touch with us.",
+        "href": "/contact"
+      },
+      "ordf": {
+        "self": "President",
+        "desc": "For questions about the organisation.",
+        "href": "/contact#ordf"
+      },
+      "web": {
+        "self": "Webmaster",
+        "desc": "For questions about the website or app.",
+        "href": "/contact#webmaster"
+      },
+      "anonymousForm": {
+        "self": "Anonymous Contact",
+        "desc": "Share your feedback or concerns confidentially.",
+        "href": "https://docs.google.com/forms/d/e/1FAIpQLSdZdPl14DkdlZCKS3jzO59-FvVi2ug9nYer1jhYgERanbwHoQ/viewform"
+      },
+      "klaga": {
+        "self": "Complaint",
+        "desc": "Send an anonymous complaint, opinion or report to TLTH.",
+        "href": "https://www.tlth.se/klaga"
+      }
+    },
+    "booking": "Bookings",
+    "documents": "Documents",
+    "account-settings": "Account Settings",
+    "logout": "Log out",
+    "logoutError": "Logout failed. Please try again later.",
+    "verify": "Verify Email",
+    "guild-meeting": "Guild Meeting"
+  },
+  "footer": {
+    "contact": "Contact",
+    "emergencycontact": "Emergency Contact",
+    "companies": "For Companies",
+    "webansvar": "Webmaster",
+    "ansvar": "Publisher",
+    "copyright": "F-Guild. All rights reserved in superposition in an impenetrable box."
+  },
+  "login": {
+    "login": "Log in",
+    "invalid-email-or-password": "Invalid email address or password",
+    "email": "Email",
+    "password": "Password",
+    "title": "Log in",
+    "registerPrompt": "Don't have an account? Register here.",
+    "forgotPassword": "Forgot password?",
+    "forgotEmailLabel": "Enter your email to reset password",
+    "forgotSubmit": "Send reset link",
+    "forgotLoading": "Sending...",
+    "forgotSuccess": "If your email exists, a reset link has been sent.",
+    "backToLogin": "Back to login",
+    "invalidEmailFormat": "Invalid email format"
+  },
+  "news": {
+    "self": "News",
+    "by": "Written by: ",
+    "pinned": "Pinned",
+    "see_all": "See all news",
+    "read_more": "Read more"
+  },
+  "verifyMail": {
+    "loading": "Verifying your email...",
+    "success": "Email verification succeeded!",
+    "error": "Email verification failed. The link may have expired or been invalid, or you may have already verified your email. You can go to fsektionen.se/verify with no token to get a new link.",
+    "goHome": "Go to the homepage",
+    "noToken": "You can request a new verification link by entering your email below. (if you came here from an email, check that you copied the entire link.)",
+    "requestSuccess": "A verification link has been sent to your email address if it is registered.",
+    "requestError": "Failed to send verification email. Please try again later.",
+    "emailPlaceholder": "Enter your email",
+    "requestNew": "Request New Verification Email"
+  },
+  "verifyReminder": {
+    "message": "Your account does not have a verified email. You MUST verify your email before the website will function properly.",
+    "go": "Verify Now"
+  },
+  "memberBanner": {
+    "message": "Your account is not registered as a member of the F-guild. You cannot do anything about this yourself. Contact your council chairperson or another admin within the guild to be registered as a member. Until then, you will not be able to use many of the guild's services."
+  },
+  "reset-password": {
+    "title": "Reset Password",
+    "password": "New Password",
+    "retype-password": "Retype password",
+    "passwords-do-not-match": "Passwords do not match",
+    "reset-password": "Reset Password",
+    "resetting": "Resetting your password...",
+    "reset-success": "Your password has been reset successfully!",
+    "goHome": "Go to Home",
+    "reset-error": "Password reset failed.",
+    "invalid-reset-token": "Invalid or missing reset token."
+  },
+  "register": {
+    "title": "Register for an Account",
+    "email": "Email",
+    "password": "Password",
+    "confirmPassword": "Confirm Password",
+    "firstName": "First Name",
+    "lastName": "Last Name",
+    "telephone": "Telephone Number with country code (+46)",
+    "startYear": "Start Year (optional)",
+    "submit": "Register",
+    "loginPrompt": "Already have an account? Login here.",
+    "loading": "Registering...",
+    "error": "Registration failed. Please check your details and try again.",
+    "verifyError": "Registered user, but failed to send verification email. Please try again later.",
+    "success": "Registration successful! Please check your email to verify your account.",
+    "goLogin": "Go to Login",
+    "passwordMismatch": "Passwords do not match. Please try again.",
+    "passwordNoNumber": "Password must contain at least one number.",
+    "passwordNoLetter": "Password must contain at least one english letter.",
+    "startYearInvalid": "Start year must be between 1960 and the current year.",
+    "emailInvalid": "Invalid email address",
+    "passwordShort": "Password must be at least 8 characters",
+    "firstNameRequired": "First name required",
+    "lastNameRequired": "Last name required",
+    "telephoneNumberRequired": "Telephone number required",
+    "gdprLabel": "I have read and agree to the",
+    "privacyPolicy": "privacy policy.",
+    "gdprRequired": "You must agree to the privacy policy to register."
+  },
+  "car-booking": {
+    "title": "Car Booking",
+    "description-title": "FAQ and rules",
+    "description": "As a member, you can book the guild car for your personal and guild-related needs. If you are an admin, you can manage bookings <0>here</0> instead. By booking the car, you agree to follow the rules found <1>here</1>.",
+    "faq": {
+      "title": "Frequently Asked Questions",
+      "q1": "Who can book the car?",
+      "a1": "Any member of the guild can book the car.",
+      "q2": "Car renting during the summer?",
+      "a2": "As activities are suspended during the summer, it is not easy to rent the guild's car. Contact the board (at) fsektionen.se to ask if it can be solved.",
+      "q3": "How many people can fit in the car?",
+      "a3": "The car can accommodate up to 7 people, including the driver.",
+      "q4": "What is the cargo capacity of the car?",
+      "a4": "The trunk (with the rear seats folded) is approximately (with the reservation that it is not a perfect rectangle) 190 cm deep, 130 cm wide and 80 cm high.",
+      "q5": "How much does it cost to rent the car?",
+      "a5": "Members of the F-guild pay a starting fee of SEK 150. The starting fee includes 20 kilometers, after that it costs SEK 5 per kilometer started.",
+      "q6": "What do the colors mean?",
+      "a6": "Different colors show status and ownership for each booking. An admin (the car foreman) must confirm bookings outside regular hours. The colors have the following meaning:\n- Light orange color means it's your booking, but it's not confirmed.\n- Dark orange color means it's your booking and it's confirmed.\n- Green color marks someone else's confirmed booking.\n- Yellow color shows someone else's unconfirmed booking.\n- Light blue color is used for bookings that have been added locally but haven't been retrieved from the server yet. If you see blue, something may have gone wrong, reload the page manually.",
+      "q7": "I have more questions!",
+      "a7": "You can contact the car foreman through, among other ways, the <0>contact page</0>. Please ask the car foreman or a webmaster to add the question with an answer here."
+    }
+  },
+  "room-booking": {
+    "title": "Room Bookings",
+    "description-title": "FAQ and rules",
+    "description": "As a member, you must ask an admin if you want to book a room, but you can view all room bookings here. If you are an admin, you can book rooms <0>here</0> instead.",
+    "faq": {
+      "title": "Frequently Asked Questions",
+      "q1": "Who can book the rooms?",
+      "a1": "Only admins can book the rooms. If you are a member, you can contact an admin from nämnden to ask them to book a room.",
+      "q2": "I have more questions!",
+      "a2": "There is no guild executive who is solely responsible for the room bookings. Contact the equipment master or the board if you have any questions. You can also ask them to add the question with an answer here."
+    }
+  },
+  "loading": {
+    "basic": "Loading content...",
+    "flavor_1": "Checking into Hilbert's hotel...",
+    "flavor_2": "Finding the determinant...",
+    "flavor_3": "Playing moose game...",
+    "flavor_4": "Calculating the last digit of π...",
+    "flavor_5": "Fermenting more Hilbeaux...",
+    "flavor_6": "Polishing pixels...",
+    "flavor_7": "Counting to infinity...",
+    "flavor_8": "Creating yet another Gandalf-exam...",
+    "flavor_9": "Proving the Riemann hypothesis...",
+    "flavor_10": "Changing coordinate systems...",
+    "flavor_11": "Preparing Hilbert sandwiches...",
+    "flavor_12": "Waiting for Ladok notification...",
+    "flavor_13": "Waiting for the impulse response to fade out...",
+    "flavor_14": "Responding to motion...",
+    "flavor_15": "Compiling LaTeX...",
+    "flavor_16": "Making boundary conditions homogeneous...",
+    "error_occurred": "Some error occurred:",
+    "no_error_message": "No error message available.",
+    "network_error": "Network error occurred. Please check your connection.",
+    "unauthorized": "You are not authorized to view this information. Please log in."
+  },
+  "cookieConsent": {
+    "message": "We use cookies to enhance your experience on our website (authentication, language and more). By continuing to use the site, you agree to our use of cookies.",
+    "accept": "Okay"
+  },
+  "permission-wall": {
+    "stop": "Stop",
+    "subtitle": "Slow down there!",
+    "message": "You do not have permission to view this page. If you believe this is an error, ",
+    "contact": "please contact your local webmaster",
+    "quote": "You are not a subset of the set of all users with access to this page.",
+    "quote_author": "The wise Debianne server",
+    "button": "Back to homepage"
+  },
+  "documents": {
+    "title": "Title",
+    "created_at": "Created At",
+    "private_explanation": "Members only",
+    "author": "Author",
+    "category": "Category",
+    "view": "View",
+    "view_doc": "View Document",
+    "page_title": "Documents",
+    "description": "Here you can find and view documents shared within the guild. Some documents may be only visible to members.",
+    "search_title": "Search by title or category",
+    "is_private": "Only shown to members",
+    "updated_at": "Updated At",
+    "file_name": "File Name"
+  },
+  "guild_meeting": {
+    "important_dates": "Important Dates"
+  },
+  "yes": "Yes",
+  "no": "No",
+  "not_found": "Not found",
+  "description": "Description",
+  "event_signup": {
+    "title": "Event Signup",
+    "priority": "Priority",
+    "select_priority": "Select priority group to sign up as",
+    "group_name": "Group Name",
+    "group_name_placeholder": "Enter group name (optional)",
+    "drink_package": {
+      "title": "Drink Package",
+      "none": "None",
+      "alcohol_free": "Alcohol Free",
+      "alcohol": "Alcohol"
+    },
+    "select_drink_package": "Select drink package",
+    "button": "Sign up",
+    "update_button": "Update signup",
+    "edit_button": "Edit",
+    "signoff_button": "Sign off",
+    "success_create": "Signup successful!",
+    "success_update": "Signup updated!",
+    "success_signoff": "You have signed off from the event.",
+    "error_create": "Failed to sign up: {{error}}",
+    "error_update": "Failed to update signup: {{error}}",
+    "error_signoff": "Failed to sign off: {{error}}",
+    "unknown_error": "Unknown error.",
+    "not_found": "You are not signed up for this event.",
+    "user": "User",
+    "status": "Status",
+    "confirmed": "Confirmed",
+    "pending": "Pending",
+    "period_passed_signed_up": "Signup period has ended. If you want to change or withdraw your signup, please contact the event organizer.",
+    "period_passed_not_signed_up": "Signup period has ended. You can no longer sign up. If you have any questions, please contact the event organizer.",
+    "food_preferences_title": "Food Preferences",
+    "food_preferences_explainer": "These are your saved food preferences. If something doesn't look right, please update them in your account settings.",
+    "standard_food_preferences": "Standard preferences:",
+    "other_food_preferences": "Other preferences:",
+    "none": "None",
+    "signup_not_used": "You cannot sign up for this event as it does not use the system for signing up to attend."
+  },
+  "songs": {
+    "by": "By",
+    "melody": "Melody",
+    "category": "Category",
+    "views": "Views",
+    "title": "Songs",
+    "description_subtitle": "Browse and sing along with our collection of songs.",
+    "search_placeholder": "Search songs..."
+  },
+  "gallery": {
+    "title": "Gallery",
+    "select_year": "Select year",
+    "photographers": "Photographers"
+  },
+  "post": "Council Post",
+  "elections": {
+    "ended": "Ended",
+    "left": "left",
+    "day": "{{count}} day(s)",
+    "hour": "{{count}} hour(s)",
+    "min": "{{count}} min(s)",
+    "no_visible_election": "No visible election available",
+    "post_name": "Post Name",
+    "recommended_limit": "Recommended Limit",
+    "max_limit": "Max Limit",
+    "candidation_count": "Candidates",
+    "elected_by": "Elected By",
+    "council": "Council",
+    "end_time": "End Time",
+    "search_posts_placeholder": "Search posts...",
+    "no_posts_match": "No posts match your search",
+    "view_my_candidations": "View My Candidations",
+    "add_candidation": "Add Candidation",
+    "add_nomination": "Add Nomination",
+    "select_post": "Select post",
+    "candidation_error": "Failed to submit candidation",
+    "candidation_success": "Candidation submitted successfully!",
+    "nomination_error": "Failed to submit nomination",
+    "nomination_success": "Nomination submitted successfully!",
+    "nominee_name": "Nominee Name",
+    "nominee_email": "Nominee Email",
+    "motivation": "Motivation",
+    "election_limits": "Election Limits",
+    "ends_in": "Ends In",
+    "actions": "Actions",
+    "candidated_status": "Candidation Status",
+    "you_have_candidated": "You have candidated for this post",
+    "candidated_at": "Candidated at",
+    "remove_candidation": "Remove Candidation",
+    "elected_at_semester": "Elected At Semester",
+    "no_description": "No description available",
+    "my_candidations": {
+      "page_title": "My Candidations",
+      "page_description": "Here you can view and manage your election candidations"
+    },
+    "back_to_elections": "Back to Elections",
+    "no_candidations": "You have no candidations",
+    "delete_candidation_success": "Candidation deleted successfully",
+    "error_delete_candidation": "Failed to delete candidation",
+    "limits": "Limits",
+    "no_limit": "No limit",
+    "no_end_time": "No end time",
+    "election_table_description": "Here is a list of all posts open for nominations and candidations. The limits for how many people can be elected to each post are ordered by recommended limit first, followed by the max limit.",
+    "sub_election": "Election category"
+  },
+  "info_box": {
+    "title": "Details"
+  }
 }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -369,8 +369,7 @@
 		"contact": "please contact your local webmaster",
 		"quote": "You are not a subset of the set of all users with access to this page.",
 		"quote_author": "The wise Debianne server",
-		"button": "Back to homepage",
-		"error": "Failed to load permissions for unknown reasons."
+		"button": "Back to homepage"
 	},
 	"documents": {
 		"title": "Title",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1,502 +1,502 @@
 {
-  "fsek": "F-Guild",
-  "title": "Main Page",
-  "calendar": "Calendar",
-  "calendarText": "Here you can see the guild's calendar with upcoming events. Click to go to the full calendar page and then scroll down for information on how to add our events to your own calendar app.",
-  "welcome": "Welcome to the new F-Guild website!",
-  "welcomeText": "We are currently in a transition period to our new website. We are continuously working to improve the design and functionality, and add things that are currently missing compared to the old website. By the way, it can still be used at old.fsektionen.se. Since we have also replaced the server and the database, the new and old systems are separated: if you have old accounts, room bookings, settings, car bookings, etc. they will not be available through the new web and you will have to make new ones. NOTE! We plan to get rid of the old website in the near future, so please try to use the new one as much as possible. If you have any questions or comments, please do not hesitate to contact the webmasters via spindelman@fsektionen.se.",
-  "oldWebsiteButton": "Take me back to the old site...",
-  "welcomeAdmin": "If you think you should have some sort of admin access, try clicking the button below, in the navbar or going to fsektionen.se/admin. If you still don't have access, please contact the head of your council (council boss).",
-  "adminButton": "Admin Page",
-  "registerButton": "Register a new account",
-  "newsTitle": "News",
-  "newsText": "If you want to use more advanced formatting, use Mattermost until we have added more options. The news page now supports images!",
-  "cafeTitle": "Hilbert Cafe",
-  "cafeText": "Hilbert Cafe is a place for students to meet, study and socialize. Here you will eventually find more interactive information about the cafe, its opening hours and staff. The café also has its own page, and you can now sign up for café shifts on a separate page.",
-  "cafe_shift_button": "Sign up for a shift",
-  "cafe_page_button": "Main cafe page",
-  "coolThing": "A cool thing that distracts you from seeing that the page is not finished yet",
-  "back": "Back",
-  "faq": {
-    "self": "Questions answered",
-    "q1": {
-      "question": "Can I log in with my old account?",
-      "answer": "No, since we switched to a new database you need to create a new account. You can do that at fsektionen.se/register. There are many things you won't have access to until you create an account, verify your email, and become verified as a member."
-    },
-    "q2": {
-      "question": "How do I become verified as a member?",
-      "answer": "Create an account, verify your email, and add your Stil-ID (hi6122mo-s) in the user settings (check the top right corner). After this, you must wait for us to verify that you are indeed a member. At the start of the semester, this may take longer than usual. If you feel that it is taking too long, you can contact your council boss or a mentor/föset during the introduction period."
-    },
-    "q3": {
-      "question": "What do you still have left to move over?",
-      "answer": "Most things are now available. To read the governing documents in their entirety (though they are available in the document archive if you know their names) or use the proposition machine (RIP), you can use the old website. We are working as diligently as possible to ensure that everything is available on the new website. 🧡"
-    },
-    "q4": {
-      "question": "Help! I don't have any of my old admin rights!",
-      "answer": "Please wait or contact your council boss and ask them to give you the appropriate permissions."
-    },
-    "q5": {
-      "question": "I am having problems signing up to events, viewing the gallery, or other things!??",
-      "answer": "We prevent non-members and users without verified email addresses from using many of our services. Check the following: \n\nThat you really have verified your account (try fsektionen.se/verify). \nThat you are registered as a member. (look in account settings to check for both of these!) \nThat you are logged in to the correct account and have not created multiple accounts, for example one with your student email and another with your personal email. If you have more than one account and want to get rid of the bad one, contact spindelman@fsektionen.se via the email of the account you want to delete."
-    }
-  },
-  "next": "Next",
-  "previous": "Previous",
-  "page": "Page",
-  "navbar": {
-    "sektionen": {
-      "self": "The Guild",
-      "about": {
-        "self": "About Us",
-        "desc": "Welcome to our community - discover our story and values.",
-        "href": "/about"
-      },
-      "news": {
-        "self": "News",
-        "desc": "Stay up-to-date with the latest announcements.",
-        "href": "/news"
-      },
-      "calendar": {
-        "self": "Calendar",
-        "desc": "Keep track of upcoming events and activities.",
-        "href": "/calendar"
-      },
-      "councils": {
-        "self": "Councils",
-        "desc": "Get to know the teams that together form the F-Guild.",
-        "href": "/councils"
-      },
-      "documents": {
-        "self": "Documents",
-        "desc": "Here you can find all the fine documents that have been produced.",
-        "href": "/documents"
-      },
-      "privacy": {
-        "self": "Privacy Policy",
-        "desc": "Learn more about how we handle your personal data.",
-        "href": "/privacy"
-      },
-      "nollning": {
-        "self": "The Introduction",
-        "desc": "Welcome to the F-guild and congratulations on your spot on the engineering program in engineering physics, engineering mathematics, or engineering nanoscience!",
-        "href": "/nollning"
-      }
-    },
-    "engage": {
-      "self": "Get Involved",
-      "cafe": {
-        "self": "Hilbert Cafe",
-        "desc": "Meet like-minded people and enjoy the relaxing atmosphere at the café (and free lunch!).",
-        "href": "/cafe"
-      },
-      "positions": {
-        "self": "Become a Volunteer!",
-        "desc": "Want to get involved? Look here!",
-        "href": "/positions"
-      },
-      "nollningsvol": {
-        "self": "Intro-week Volunteering",
-        "desc": "Help us welcome new students and give them a great start to their studies!",
-        "href": "/nollningsvolontar"
-      },
-      "elections": {
-        "self": "Elections",
-        "desc": "Apply for the guild's positions.",
-        "href": "/election"
-      },
-      "projects": {
-        "self": "Projects",
-        "desc": "Discover innovative initiatives and collaborative efforts.",
-        "href": "/projects"
-      },
-      "freja": {
-        "self": "FREJA",
-        "desc": "FREJA is an independent organization for women or non-binary students.",
-        "href": "https://www.frejalth.se/"
-      }
-    },
-    "services": {
-      "self": "Services",
-      "car": {
-        "self": "Car Rentals",
-        "desc": "Book the guild vehicle for your travel and daily needs.",
-        "href": "/car"
-      },
-      "rooms": {
-        "self": "Room Bookings",
-        "desc": "Book the three rooms in the Mathematics building for personal events or guild meetings.",
-        "href": "/room-bookings"
-      },
-      "tools": {
-        "self": "Tool Library",
-        "desc": "Borrow the guild's high-quality tools to help bring your projects to life.",
-        "href": "/tools"
-      },
-      "specialrooms": {
-        "self": "Quiet/Prayer Rooms",
-        "desc": "Find a peaceful space for reflection or private prayer.",
-        "href": "/stillarum"
-      },
-      "gallery": {
-        "self": "Gallery",
-        "desc": "Explore our photo gallery and get a glimpse into the guild's history.",
-        "href": "/gallery"
-      },
-      "calendar": {
-        "self": "Calendar",
-        "desc": "Keep track of upcoming events and activities.",
-        "href": "/calendar"
-      },
-      "songs": {
-        "self": "Songs",
-        "desc": "Browse the songs heard and sung at the guild's events.",
-        "href": "/songs"
-      }
-    },
-    "companies": {
-      "self": "Companies",
-      "aboutCompany": {
-        "self": "About Us",
-        "desc": "Discover who we are and what programs we represent.",
-        "href": "/foretag/om"
-      },
-      "offerings": {
-        "self": "Our Offerings",
-        "desc": "Explore proposals for ways to cooperate to reach our members.",
-        "href": "/foretag/vi-erbjuder"
-      },
-      "farad": {
-        "self": "Farad",
-        "desc": "Read about the job fair for the F-Guild.",
-        "href": "https://farad.nu"
-      },
-      "contact": {
-        "self": "Business Contact",
-        "desc": "Reach out to us for partnership and business inquiries.",
-        "href": "/contact#naringslivsutskottet"
-      }
-    },
-    "contact": {
-      "self": "Contact",
-      "contactPage": {
-        "self": "Contact Page",
-        "desc": "Find all the information you need to get in touch with us.",
-        "href": "/contact"
-      },
-      "ordf": {
-        "self": "President",
-        "desc": "For questions about the organisation.",
-        "href": "/contact#ordf"
-      },
-      "web": {
-        "self": "Webmaster",
-        "desc": "For questions about the website or app.",
-        "href": "/contact#webmaster"
-      },
-      "anonymousForm": {
-        "self": "Anonymous Contact",
-        "desc": "Share your feedback or concerns confidentially.",
-        "href": "https://docs.google.com/forms/d/e/1FAIpQLSdZdPl14DkdlZCKS3jzO59-FvVi2ug9nYer1jhYgERanbwHoQ/viewform"
-      },
-      "klaga": {
-        "self": "Complaint",
-        "desc": "Send an anonymous complaint, opinion or report to TLTH.",
-        "href": "https://www.tlth.se/klaga"
-      }
-    },
-    "booking": "Bookings",
-    "documents": "Documents",
-    "account-settings": "Account Settings",
-    "logout": "Log out",
-    "logoutError": "Logout failed. Please try again later.",
-    "verify": "Verify Email",
-    "guild-meeting": "Guild Meeting"
-  },
-  "footer": {
-    "contact": "Contact",
-    "emergencycontact": "Emergency Contact",
-    "companies": "For Companies",
-    "webansvar": "Webmaster",
-    "ansvar": "Publisher",
-    "copyright": "F-Guild. All rights reserved in superposition in an impenetrable box."
-  },
-  "login": {
-    "login": "Log in",
-    "invalid-email-or-password": "Invalid email address or password",
-    "email": "Email",
-    "password": "Password",
-    "title": "Log in",
-    "registerPrompt": "Don't have an account? Register here.",
-    "forgotPassword": "Forgot password?",
-    "forgotEmailLabel": "Enter your email to reset password",
-    "forgotSubmit": "Send reset link",
-    "forgotLoading": "Sending...",
-    "forgotSuccess": "If your email exists, a reset link has been sent.",
-    "backToLogin": "Back to login",
-    "invalidEmailFormat": "Invalid email format"
-  },
-  "news": {
-    "self": "News",
-    "by": "Written by: ",
-    "pinned": "Pinned",
-    "see_all": "See all news",
-    "read_more": "Read more"
-  },
-  "verifyMail": {
-    "loading": "Verifying your email...",
-    "success": "Email verification succeeded!",
-    "error": "Email verification failed. The link may have expired or been invalid, or you may have already verified your email. You can go to fsektionen.se/verify with no token to get a new link.",
-    "goHome": "Go to the homepage",
-    "noToken": "You can request a new verification link by entering your email below. (if you came here from an email, check that you copied the entire link.)",
-    "requestSuccess": "A verification link has been sent to your email address if it is registered.",
-    "requestError": "Failed to send verification email. Please try again later.",
-    "emailPlaceholder": "Enter your email",
-    "requestNew": "Request New Verification Email"
-  },
-  "verifyReminder": {
-    "message": "Your account does not have a verified email. You MUST verify your email before the website will function properly.",
-    "go": "Verify Now"
-  },
-  "memberBanner": {
-    "message": "Your account is not registered as a member of the F-guild. You cannot do anything about this yourself. Contact your council chairperson or another admin within the guild to be registered as a member. Until then, you will not be able to use many of the guild's services."
-  },
-  "reset-password": {
-    "title": "Reset Password",
-    "password": "New Password",
-    "retype-password": "Retype password",
-    "passwords-do-not-match": "Passwords do not match",
-    "reset-password": "Reset Password",
-    "resetting": "Resetting your password...",
-    "reset-success": "Your password has been reset successfully!",
-    "goHome": "Go to Home",
-    "reset-error": "Password reset failed.",
-    "invalid-reset-token": "Invalid or missing reset token."
-  },
-  "register": {
-    "title": "Register for an Account",
-    "email": "Email",
-    "password": "Password",
-    "confirmPassword": "Confirm Password",
-    "firstName": "First Name",
-    "lastName": "Last Name",
-    "telephone": "Telephone Number with country code (+46)",
-    "startYear": "Start Year (optional)",
-    "submit": "Register",
-    "loginPrompt": "Already have an account? Login here.",
-    "loading": "Registering...",
-    "error": "Registration failed. Please check your details and try again.",
-    "verifyError": "Registered user, but failed to send verification email. Please try again later.",
-    "success": "Registration successful! Please check your email to verify your account.",
-    "goLogin": "Go to Login",
-    "passwordMismatch": "Passwords do not match. Please try again.",
-    "passwordNoNumber": "Password must contain at least one number.",
-    "passwordNoLetter": "Password must contain at least one english letter.",
-    "startYearInvalid": "Start year must be between 1960 and the current year.",
-    "emailInvalid": "Invalid email address",
-    "passwordShort": "Password must be at least 8 characters",
-    "firstNameRequired": "First name required",
-    "lastNameRequired": "Last name required",
-    "telephoneNumberRequired": "Telephone number required",
-    "gdprLabel": "I have read and agree to the",
-    "privacyPolicy": "privacy policy.",
-    "gdprRequired": "You must agree to the privacy policy to register."
-  },
-  "car-booking": {
-    "title": "Car Booking",
-    "description-title": "FAQ and rules",
-    "description": "As a member, you can book the guild car for your personal and guild-related needs. If you are an admin, you can manage bookings <0>here</0> instead. By booking the car, you agree to follow the rules found <1>here</1>.",
-    "faq": {
-      "title": "Frequently Asked Questions",
-      "q1": "Who can book the car?",
-      "a1": "Any member of the guild can book the car.",
-      "q2": "Car renting during the summer?",
-      "a2": "As activities are suspended during the summer, it is not easy to rent the guild's car. Contact the board (at) fsektionen.se to ask if it can be solved.",
-      "q3": "How many people can fit in the car?",
-      "a3": "The car can accommodate up to 7 people, including the driver.",
-      "q4": "What is the cargo capacity of the car?",
-      "a4": "The trunk (with the rear seats folded) is approximately (with the reservation that it is not a perfect rectangle) 190 cm deep, 130 cm wide and 80 cm high.",
-      "q5": "How much does it cost to rent the car?",
-      "a5": "Members of the F-guild pay a starting fee of SEK 150. The starting fee includes 20 kilometers, after that it costs SEK 5 per kilometer started.",
-      "q6": "What do the colors mean?",
-      "a6": "Different colors show status and ownership for each booking. An admin (the car foreman) must confirm bookings outside regular hours. The colors have the following meaning:\n- Light orange color means it's your booking, but it's not confirmed.\n- Dark orange color means it's your booking and it's confirmed.\n- Green color marks someone else's confirmed booking.\n- Yellow color shows someone else's unconfirmed booking.\n- Light blue color is used for bookings that have been added locally but haven't been retrieved from the server yet. If you see blue, something may have gone wrong, reload the page manually.",
-      "q7": "I have more questions!",
-      "a7": "You can contact the car foreman through, among other ways, the <0>contact page</0>. Please ask the car foreman or a webmaster to add the question with an answer here."
-    }
-  },
-  "room-booking": {
-    "title": "Room Bookings",
-    "description-title": "FAQ and rules",
-    "description": "As a member, you must ask an admin if you want to book a room, but you can view all room bookings here. If you are an admin, you can book rooms <0>here</0> instead.",
-    "faq": {
-      "title": "Frequently Asked Questions",
-      "q1": "Who can book the rooms?",
-      "a1": "Only admins can book the rooms. If you are a member, you can contact an admin from nämnden to ask them to book a room.",
-      "q2": "I have more questions!",
-      "a2": "There is no guild executive who is solely responsible for the room bookings. Contact the equipment master or the board if you have any questions. You can also ask them to add the question with an answer here."
-    }
-  },
-  "loading": {
-    "basic": "Loading content...",
-    "flavor_1": "Checking into Hilbert's hotel...",
-    "flavor_2": "Finding the determinant...",
-    "flavor_3": "Playing moose game...",
-    "flavor_4": "Calculating the last digit of π...",
-    "flavor_5": "Fermenting more Hilbeaux...",
-    "flavor_6": "Polishing pixels...",
-    "flavor_7": "Counting to infinity...",
-    "flavor_8": "Creating yet another Gandalf-exam...",
-    "flavor_9": "Proving the Riemann hypothesis...",
-    "flavor_10": "Changing coordinate systems...",
-    "flavor_11": "Preparing Hilbert sandwiches...",
-    "flavor_12": "Waiting for Ladok notification...",
-    "flavor_13": "Waiting for the impulse response to fade out...",
-    "flavor_14": "Responding to motion...",
-    "flavor_15": "Compiling LaTeX...",
-    "flavor_16": "Making boundary conditions homogeneous...",
-    "error_occurred": "Some error occurred:",
-    "no_error_message": "No error message available.",
-    "network_error": "Network error occurred. Please check your connection.",
-    "unauthorized": "You are not authorized to view this information. Please log in."
-  },
-  "cookieConsent": {
-    "message": "We use cookies to enhance your experience on our website (authentication, language and more). By continuing to use the site, you agree to our use of cookies.",
-    "accept": "Okay"
-  },
-  "permission-wall": {
-    "stop": "Stop",
-    "subtitle": "Slow down there!",
-    "message": "You do not have permission to view this page. If you believe this is an error, ",
-    "contact": "please contact your local webmaster",
-    "quote": "You are not a subset of the set of all users with access to this page.",
-    "quote_author": "The wise Debianne server",
-    "button": "Back to homepage"
-  },
-  "documents": {
-    "title": "Title",
-    "created_at": "Created At",
-    "private_explanation": "Members only",
-    "author": "Author",
-    "category": "Category",
-    "view": "View",
-    "view_doc": "View Document",
-    "page_title": "Documents",
-    "description": "Here you can find and view documents shared within the guild. Some documents may be only visible to members.",
-    "search_title": "Search by title or category",
-    "is_private": "Only shown to members",
-    "updated_at": "Updated At",
-    "file_name": "File Name"
-  },
-  "guild_meeting": {
-    "important_dates": "Important Dates"
-  },
-  "yes": "Yes",
-  "no": "No",
-  "not_found": "Not found",
-  "description": "Description",
-  "event_signup": {
-    "title": "Event Signup",
-    "priority": "Priority",
-    "select_priority": "Select priority group to sign up as",
-    "group_name": "Group Name",
-    "group_name_placeholder": "Enter group name (optional)",
-    "drink_package": {
-      "title": "Drink Package",
-      "none": "None",
-      "alcohol_free": "Alcohol Free",
-      "alcohol": "Alcohol"
-    },
-    "select_drink_package": "Select drink package",
-    "button": "Sign up",
-    "update_button": "Update signup",
-    "edit_button": "Edit",
-    "signoff_button": "Sign off",
-    "success_create": "Signup successful!",
-    "success_update": "Signup updated!",
-    "success_signoff": "You have signed off from the event.",
-    "error_create": "Failed to sign up: {{error}}",
-    "error_update": "Failed to update signup: {{error}}",
-    "error_signoff": "Failed to sign off: {{error}}",
-    "unknown_error": "Unknown error.",
-    "not_found": "You are not signed up for this event.",
-    "user": "User",
-    "status": "Status",
-    "confirmed": "Confirmed",
-    "pending": "Pending",
-    "period_passed_signed_up": "Signup period has ended. If you want to change or withdraw your signup, please contact the event organizer.",
-    "period_passed_not_signed_up": "Signup period has ended. You can no longer sign up. If you have any questions, please contact the event organizer.",
-    "food_preferences_title": "Food Preferences",
-    "food_preferences_explainer": "These are your saved food preferences. If something doesn't look right, please update them in your account settings.",
-    "standard_food_preferences": "Standard preferences:",
-    "other_food_preferences": "Other preferences:",
-    "none": "None",
-    "signup_not_used": "You cannot sign up for this event as it does not use the system for signing up to attend."
-  },
-  "songs": {
-    "by": "By",
-    "melody": "Melody",
-    "category": "Category",
-    "views": "Views",
-    "title": "Songs",
-    "description_subtitle": "Browse and sing along with our collection of songs.",
-    "search_placeholder": "Search songs..."
-  },
-  "gallery": {
-    "title": "Gallery",
-    "select_year": "Select year",
-    "photographers": "Photographers"
-  },
-  "post": "Council Post",
-  "elections": {
-    "ended": "Ended",
-    "left": "left",
-    "day": "{{count}} day(s)",
-    "hour": "{{count}} hour(s)",
-    "min": "{{count}} min(s)",
-    "no_visible_election": "No visible election available",
-    "post_name": "Post Name",
-    "recommended_limit": "Recommended Limit",
-    "max_limit": "Max Limit",
-    "candidation_count": "Candidates",
-    "elected_by": "Elected By",
-    "council": "Council",
-    "end_time": "End Time",
-    "search_posts_placeholder": "Search posts...",
-    "no_posts_match": "No posts match your search",
-    "view_my_candidations": "View My Candidations",
-    "add_candidation": "Add Candidation",
-    "add_nomination": "Add Nomination",
-    "select_post": "Select post",
-    "candidation_error": "Failed to submit candidation",
-    "candidation_success": "Candidation submitted successfully!",
-    "nomination_error": "Failed to submit nomination",
-    "nomination_success": "Nomination submitted successfully!",
-    "nominee_name": "Nominee Name",
-    "nominee_email": "Nominee Email",
-    "motivation": "Motivation",
-    "election_limits": "Election Limits",
-    "ends_in": "Ends In",
-    "actions": "Actions",
-    "candidated_status": "Candidation Status",
-    "you_have_candidated": "You have candidated for this post",
-    "candidated_at": "Candidated at",
-    "remove_candidation": "Remove Candidation",
-    "elected_at_semester": "Elected At Semester",
-    "no_description": "No description available",
-    "my_candidations": {
-      "page_title": "My Candidations",
-      "page_description": "Here you can view and manage your election candidations"
-    },
-    "back_to_elections": "Back to Elections",
-    "no_candidations": "You have no candidations",
-    "delete_candidation_success": "Candidation deleted successfully",
-    "error_delete_candidation": "Failed to delete candidation",
-    "limits": "Limits",
-    "no_limit": "No limit",
-    "no_end_time": "No end time",
-    "election_table_description": "Here is a list of all posts open for nominations and candidations. The limits for how many people can be elected to each post are ordered by recommended limit first, followed by the max limit.",
-    "sub_election": "Election category"
-  },
-  "info_box": {
-    "title": "Details"
-  }
+	"fsek": "F-Guild",
+	"title": "Main Page",
+	"calendar": "Calendar",
+	"calendarText": "Here you can see the guild's calendar with upcoming events. Click to go to the full calendar page and then scroll down for information on how to add our events to your own calendar app.",
+	"welcome": "Welcome to the new F-Guild website!",
+	"welcomeText": "We are currently in a transition period to our new website. We are continuously working to improve the design and functionality, and add things that are currently missing compared to the old website. By the way, it can still be used at old.fsektionen.se. Since we have also replaced the server and the database, the new and old systems are separated: if you have old accounts, room bookings, settings, car bookings, etc. they will not be available through the new web and you will have to make new ones. NOTE! We plan to get rid of the old website in the near future, so please try to use the new one as much as possible. If you have any questions or comments, please do not hesitate to contact the webmasters via spindelman@fsektionen.se.",
+	"oldWebsiteButton": "Take me back to the old site...",
+	"welcomeAdmin": "If you think you should have some sort of admin access, try clicking the button below, in the navbar or going to fsektionen.se/admin. If you still don't have access, please contact the head of your council (council boss).",
+	"adminButton": "Admin Page",
+	"registerButton": "Register a new account",
+	"newsTitle": "News",
+	"newsText": "If you want to use more advanced formatting, use Mattermost until we have added more options. The news page now supports images!",
+	"cafeTitle": "Hilbert Cafe",
+	"cafeText": "Hilbert Cafe is a place for students to meet, study and socialize. Here you will eventually find more interactive information about the cafe, its opening hours and staff. The café also has its own page, and you can now sign up for café shifts on a separate page.",
+	"cafe_shift_button": "Sign up for a shift",
+	"cafe_page_button": "Main cafe page",
+	"coolThing": "A cool thing that distracts you from seeing that the page is not finished yet",
+	"back": "Back",
+	"faq": {
+		"self": "Questions answered",
+		"q1": {
+			"question": "Can I log in with my old account?",
+			"answer": "No, since we switched to a new database you need to create a new account. You can do that at fsektionen.se/register. There are many things you won't have access to until you create an account, verify your email, and become verified as a member."
+		},
+		"q2": {
+			"question": "How do I become verified as a member?",
+			"answer": "Create an account, verify your email, and add your Stil-ID (hi6122mo-s) in the user settings (check the top right corner). After this, you must wait for us to verify that you are indeed a member. At the start of the semester, this may take longer than usual. If you feel that it is taking too long, you can contact your council boss or a mentor/föset during the introduction period."
+		},
+		"q3": {
+			"question": "What do you still have left to move over?",
+			"answer": "Most things are now available. To read the governing documents in their entirety (though they are available in the document archive if you know their names) or use the proposition machine (RIP), you can use the old website. We are working as diligently as possible to ensure that everything is available on the new website. 🧡"
+		},
+		"q4": {
+			"question": "Help! I don't have any of my old admin rights!",
+			"answer": "Please wait or contact your council boss and ask them to give you the appropriate permissions."
+		},
+		"q5": {
+			"question": "I am having problems signing up to events, viewing the gallery, or other things!??",
+			"answer": "We prevent non-members and users without verified email addresses from using many of our services. Check the following: \n\nThat you really have verified your account (try fsektionen.se/verify). \nThat you are registered as a member. (look in account settings to check for both of these!) \nThat you are logged in to the correct account and have not created multiple accounts, for example one with your student email and another with your personal email. If you have more than one account and want to get rid of the bad one, contact spindelman@fsektionen.se via the email of the account you want to delete."
+		}
+	},
+	"next": "Next",
+	"previous": "Previous",
+	"page": "Page",
+	"navbar": {
+		"sektionen": {
+			"self": "The Guild",
+			"about": {
+				"self": "About Us",
+				"desc": "Welcome to our community - discover our story and values.",
+				"href": "/about"
+			},
+			"news": {
+				"self": "News",
+				"desc": "Stay up-to-date with the latest announcements.",
+				"href": "/news"
+			},
+			"calendar": {
+				"self": "Calendar",
+				"desc": "Keep track of upcoming events and activities.",
+				"href": "/calendar"
+			},
+			"councils": {
+				"self": "Councils",
+				"desc": "Get to know the teams that together form the F-Guild.",
+				"href": "/councils"
+			},
+			"documents": {
+				"self": "Documents",
+				"desc": "Here you can find all the fine documents that have been produced.",
+				"href": "/documents"
+			},
+			"privacy": {
+				"self": "Privacy Policy",
+				"desc": "Learn more about how we handle your personal data.",
+				"href": "/privacy"
+			},
+			"nollning": {
+				"self": "The Introduction",
+				"desc": "Welcome to the F-guild and congratulations on your spot on the engineering program in engineering physics, engineering mathematics, or engineering nanoscience!",
+				"href": "/nollning"
+			}
+		},
+		"engage": {
+			"self": "Get Involved",
+			"cafe": {
+				"self": "Hilbert Cafe",
+				"desc": "Meet like-minded people and enjoy the relaxing atmosphere at the café (and free lunch!).",
+				"href": "/cafe"
+			},
+			"positions": {
+				"self": "Become a Volunteer!",
+				"desc": "Want to get involved? Look here!",
+				"href": "/positions"
+			},
+			"nollningsvol": {
+				"self": "Intro-week Volunteering",
+				"desc": "Help us welcome new students and give them a great start to their studies!",
+				"href": "/nollningsvolontar"
+			},
+			"elections": {
+				"self": "Elections",
+				"desc": "Apply for the guild's positions.",
+				"href": "/election"
+			},
+			"projects": {
+				"self": "Projects",
+				"desc": "Discover innovative initiatives and collaborative efforts.",
+				"href": "/projects"
+			},
+			"freja": {
+				"self": "FREJA",
+				"desc": "FREJA is an independent organization for women or non-binary students.",
+				"href": "https://www.frejalth.se/"
+			}
+		},
+		"services": {
+			"self": "Services",
+			"car": {
+				"self": "Car Rentals",
+				"desc": "Book the guild vehicle for your travel and daily needs.",
+				"href": "/car"
+			},
+			"rooms": {
+				"self": "Room Bookings",
+				"desc": "Book the three rooms in the Mathematics building for personal events or guild meetings.",
+				"href": "/room-bookings"
+			},
+			"tools": {
+				"self": "Tool Library",
+				"desc": "Borrow the guild's high-quality tools to help bring your projects to life.",
+				"href": "/tools"
+			},
+			"specialrooms": {
+				"self": "Quiet/Prayer Rooms",
+				"desc": "Find a peaceful space for reflection or private prayer.",
+				"href": "/stillarum"
+			},
+			"gallery": {
+				"self": "Gallery",
+				"desc": "Explore our photo gallery and get a glimpse into the guild's history.",
+				"href": "/gallery"
+			},
+			"calendar": {
+				"self": "Calendar",
+				"desc": "Keep track of upcoming events and activities.",
+				"href": "/calendar"
+			},
+			"songs": {
+				"self": "Songs",
+				"desc": "Browse the songs heard and sung at the guild's events.",
+				"href": "/songs"
+			}
+		},
+		"companies": {
+			"self": "Companies",
+			"aboutCompany": {
+				"self": "About Us",
+				"desc": "Discover who we are and what programs we represent.",
+				"href": "/foretag/om"
+			},
+			"offerings": {
+				"self": "Our Offerings",
+				"desc": "Explore proposals for ways to cooperate to reach our members.",
+				"href": "/foretag/vi-erbjuder"
+			},
+			"farad": {
+				"self": "Farad",
+				"desc": "Read about the job fair for the F-Guild.",
+				"href": "https://farad.nu"
+			},
+			"contact": {
+				"self": "Business Contact",
+				"desc": "Reach out to us for partnership and business inquiries.",
+				"href": "/contact#naringslivsutskottet"
+			}
+		},
+		"contact": {
+			"self": "Contact",
+			"contactPage": {
+				"self": "Contact Page",
+				"desc": "Find all the information you need to get in touch with us.",
+				"href": "/contact"
+			},
+			"ordf": {
+				"self": "President",
+				"desc": "For questions about the organisation.",
+				"href": "/contact#ordf"
+			},
+			"web": {
+				"self": "Webmaster",
+				"desc": "For questions about the website or app.",
+				"href": "/contact#webmaster"
+			},
+			"anonymousForm": {
+				"self": "Anonymous Contact",
+				"desc": "Share your feedback or concerns confidentially.",
+				"href": "https://docs.google.com/forms/d/e/1FAIpQLSdZdPl14DkdlZCKS3jzO59-FvVi2ug9nYer1jhYgERanbwHoQ/viewform"
+			},
+			"klaga": {
+				"self": "Complaint",
+				"desc": "Send an anonymous complaint, opinion or report to TLTH.",
+				"href": "https://www.tlth.se/klaga"
+			}
+		},
+		"booking": "Bookings",
+		"documents": "Documents",
+		"account-settings": "Account Settings",
+		"logout": "Log out",
+		"logoutError": "Logout failed. Please try again later.",
+		"verify": "Verify Email",
+		"guild-meeting": "Guild Meeting"
+	},
+	"footer": {
+		"contact": "Contact",
+		"emergencycontact": "Emergency Contact",
+		"companies": "For Companies",
+		"webansvar": "Webmaster",
+		"ansvar": "Publisher",
+		"copyright": "F-Guild. All rights reserved in superposition in an impenetrable box."
+	},
+	"login": {
+		"login": "Log in",
+		"invalid-email-or-password": "Invalid email address or password",
+		"email": "Email",
+		"password": "Password",
+		"title": "Log in",
+		"registerPrompt": "Don't have an account? Register here.",
+		"forgotPassword": "Forgot password?",
+		"forgotEmailLabel": "Enter your email to reset password",
+		"forgotSubmit": "Send reset link",
+		"forgotLoading": "Sending...",
+		"forgotSuccess": "If your email exists, a reset link has been sent.",
+		"backToLogin": "Back to login",
+		"invalidEmailFormat": "Invalid email format"
+	},
+	"news": {
+		"self": "News",
+		"by": "Written by: ",
+		"pinned": "Pinned",
+		"see_all": "See all news",
+		"read_more": "Read more"
+	},
+	"verifyMail": {
+		"loading": "Verifying your email...",
+		"success": "Email verification succeeded!",
+		"error": "Email verification failed. The link may have expired or been invalid, or you may have already verified your email. You can go to fsektionen.se/verify with no token to get a new link.",
+		"goHome": "Go to the homepage",
+		"noToken": "You can request a new verification link by entering your email below. (if you came here from an email, check that you copied the entire link.)",
+		"requestSuccess": "A verification link has been sent to your email address if it is registered.",
+		"requestError": "Failed to send verification email. Please try again later.",
+		"emailPlaceholder": "Enter your email",
+		"requestNew": "Request New Verification Email"
+	},
+	"verifyReminder": {
+		"message": "Your account does not have a verified email. You MUST verify your email before the website will function properly.",
+		"go": "Verify Now"
+	},
+	"memberBanner": {
+		"message": "Your account is not registered as a member of the F-guild. You cannot do anything about this yourself. Contact your council chairperson or another admin within the guild to be registered as a member. Until then, you will not be able to use many of the guild's services."
+	},
+	"reset-password": {
+		"title": "Reset Password",
+		"password": "New Password",
+		"retype-password": "Retype password",
+		"passwords-do-not-match": "Passwords do not match",
+		"reset-password": "Reset Password",
+		"resetting": "Resetting your password...",
+		"reset-success": "Your password has been reset successfully!",
+		"goHome": "Go to Home",
+		"reset-error": "Password reset failed.",
+		"invalid-reset-token": "Invalid or missing reset token."
+	},
+	"register": {
+		"title": "Register for an Account",
+		"email": "Email",
+		"password": "Password",
+		"confirmPassword": "Confirm Password",
+		"firstName": "First Name",
+		"lastName": "Last Name",
+		"telephone": "Telephone Number with country code (+46)",
+		"startYear": "Start Year (optional)",
+		"submit": "Register",
+		"loginPrompt": "Already have an account? Login here.",
+		"loading": "Registering...",
+		"error": "Registration failed. Please check your details and try again.",
+		"verifyError": "Registered user, but failed to send verification email. Please try again later.",
+		"success": "Registration successful! Please check your email to verify your account.",
+		"goLogin": "Go to Login",
+		"passwordMismatch": "Passwords do not match. Please try again.",
+		"passwordNoNumber": "Password must contain at least one number.",
+		"passwordNoLetter": "Password must contain at least one english letter.",
+		"startYearInvalid": "Start year must be between 1960 and the current year.",
+		"emailInvalid": "Invalid email address",
+		"passwordShort": "Password must be at least 8 characters",
+		"firstNameRequired": "First name required",
+		"lastNameRequired": "Last name required",
+		"telephoneNumberRequired": "Telephone number required",
+		"gdprLabel": "I have read and agree to the",
+		"privacyPolicy": "privacy policy.",
+		"gdprRequired": "You must agree to the privacy policy to register."
+	},
+	"car-booking": {
+		"title": "Car Booking",
+		"description-title": "FAQ and rules",
+		"description": "As a member, you can book the guild car for your personal and guild-related needs. If you are an admin, you can manage bookings <0>here</0> instead. By booking the car, you agree to follow the rules found <1>here</1>.",
+		"faq": {
+			"title": "Frequently Asked Questions",
+			"q1": "Who can book the car?",
+			"a1": "Any member of the guild can book the car.",
+			"q2": "Car renting during the summer?",
+			"a2": "As activities are suspended during the summer, it is not easy to rent the guild's car. Contact the board (at) fsektionen.se to ask if it can be solved.",
+			"q3": "How many people can fit in the car?",
+			"a3": "The car can accommodate up to 7 people, including the driver.",
+			"q4": "What is the cargo capacity of the car?",
+			"a4": "The trunk (with the rear seats folded) is approximately (with the reservation that it is not a perfect rectangle) 190 cm deep, 130 cm wide and 80 cm high.",
+			"q5": "How much does it cost to rent the car?",
+			"a5": "Members of the F-guild pay a starting fee of SEK 150. The starting fee includes 20 kilometers, after that it costs SEK 5 per kilometer started.",
+			"q6": "What do the colors mean?",
+			"a6": "Different colors show status and ownership for each booking. An admin (the car foreman) must confirm bookings outside regular hours. The colors have the following meaning:\n- Light orange color means it's your booking, but it's not confirmed.\n- Dark orange color means it's your booking and it's confirmed.\n- Green color marks someone else's confirmed booking.\n- Yellow color shows someone else's unconfirmed booking.\n- Light blue color is used for bookings that have been added locally but haven't been retrieved from the server yet. If you see blue, something may have gone wrong, reload the page manually.",
+			"q7": "I have more questions!",
+			"a7": "You can contact the car foreman through, among other ways, the <0>contact page</0>. Please ask the car foreman or a webmaster to add the question with an answer here."
+		}
+	},
+	"room-booking": {
+		"title": "Room Bookings",
+		"description-title": "FAQ and rules",
+		"description": "As a member, you must ask an admin if you want to book a room, but you can view all room bookings here. If you are an admin, you can book rooms <0>here</0> instead.",
+		"faq": {
+			"title": "Frequently Asked Questions",
+			"q1": "Who can book the rooms?",
+			"a1": "Only admins can book the rooms. If you are a member, you can contact an admin from nämnden to ask them to book a room.",
+			"q2": "I have more questions!",
+			"a2": "There is no guild executive who is solely responsible for the room bookings. Contact the equipment master or the board if you have any questions. You can also ask them to add the question with an answer here."
+		}
+	},
+	"loading": {
+		"basic": "Loading content...",
+		"flavor_1": "Checking into Hilbert's hotel...",
+		"flavor_2": "Finding the determinant...",
+		"flavor_3": "Playing moose game...",
+		"flavor_4": "Calculating the last digit of π...",
+		"flavor_5": "Fermenting more Hilbeaux...",
+		"flavor_6": "Polishing pixels...",
+		"flavor_7": "Counting to infinity...",
+		"flavor_8": "Creating yet another Gandalf-exam...",
+		"flavor_9": "Proving the Riemann hypothesis...",
+		"flavor_10": "Changing coordinate systems...",
+		"flavor_11": "Preparing Hilbert sandwiches...",
+		"flavor_12": "Waiting for Ladok notification...",
+		"flavor_13": "Waiting for the impulse response to fade out...",
+		"flavor_14": "Responding to motion...",
+		"flavor_15": "Compiling LaTeX...",
+		"flavor_16": "Making boundary conditions homogeneous...",
+		"error_occurred": "Some error occurred:",
+		"no_error_message": "No error message available.",
+		"network_error": "Network error occurred. Please check your connection.",
+		"unauthorized": "You are not authorized to view this information. Please log in."
+	},
+	"cookieConsent": {
+		"message": "We use cookies to enhance your experience on our website (authentication, language and more). By continuing to use the site, you agree to our use of cookies.",
+		"accept": "Okay"
+	},
+	"permission-wall": {
+		"stop": "Stop",
+		"subtitle": "Slow down there!",
+		"message": "You do not have permission to view this page. If you believe this is an error, ",
+		"contact": "please contact your local webmaster",
+		"quote": "You are not a subset of the set of all users with access to this page.",
+		"quote_author": "The wise Debianne server",
+		"button": "Back to homepage"
+	},
+	"documents": {
+		"title": "Title",
+		"created_at": "Created At",
+		"private_explanation": "Members only",
+		"author": "Author",
+		"category": "Category",
+		"view": "View",
+		"view_doc": "View Document",
+		"page_title": "Documents",
+		"description": "Here you can find and view documents shared within the guild. Some documents may be only visible to members.",
+		"search_title": "Search by title or category",
+		"is_private": "Only shown to members",
+		"updated_at": "Updated At",
+		"file_name": "File Name"
+	},
+	"guild_meeting": {
+		"important_dates": "Important Dates"
+	},
+	"yes": "Yes",
+	"no": "No",
+	"not_found": "Not found",
+	"description": "Description",
+	"event_signup": {
+		"title": "Event Signup",
+		"priority": "Priority",
+		"select_priority": "Select priority group to sign up as",
+		"group_name": "Group Name",
+		"group_name_placeholder": "Enter group name (optional)",
+		"drink_package": {
+			"title": "Drink Package",
+			"none": "None",
+			"alcohol_free": "Alcohol Free",
+			"alcohol": "Alcohol"
+		},
+		"select_drink_package": "Select drink package",
+		"button": "Sign up",
+		"update_button": "Update signup",
+		"edit_button": "Edit",
+		"signoff_button": "Sign off",
+		"success_create": "Signup successful!",
+		"success_update": "Signup updated!",
+		"success_signoff": "You have signed off from the event.",
+		"error_create": "Failed to sign up: {{error}}",
+		"error_update": "Failed to update signup: {{error}}",
+		"error_signoff": "Failed to sign off: {{error}}",
+		"unknown_error": "Unknown error.",
+		"not_found": "You are not signed up for this event.",
+		"user": "User",
+		"status": "Status",
+		"confirmed": "Confirmed",
+		"pending": "Pending",
+		"period_passed_signed_up": "Signup period has ended. If you want to change or withdraw your signup, please contact the event organizer.",
+		"period_passed_not_signed_up": "Signup period has ended. You can no longer sign up. If you have any questions, please contact the event organizer.",
+		"food_preferences_title": "Food Preferences",
+		"food_preferences_explainer": "These are your saved food preferences. If something doesn't look right, please update them in your account settings.",
+		"standard_food_preferences": "Standard preferences:",
+		"other_food_preferences": "Other preferences:",
+		"none": "None",
+		"signup_not_used": "You cannot sign up for this event as it does not use the system for signing up to attend."
+	},
+	"songs": {
+		"by": "By",
+		"melody": "Melody",
+		"category": "Category",
+		"views": "Views",
+		"title": "Songs",
+		"description_subtitle": "Browse and sing along with our collection of songs.",
+		"search_placeholder": "Search songs..."
+	},
+	"gallery": {
+		"title": "Gallery",
+		"select_year": "Select year",
+		"photographers": "Photographers"
+	},
+	"post": "Council Post",
+	"elections": {
+		"ended": "Ended",
+		"left": "left",
+		"day": "{{count}} day(s)",
+		"hour": "{{count}} hour(s)",
+		"min": "{{count}} min(s)",
+		"no_visible_election": "No visible election available",
+		"post_name": "Post Name",
+		"recommended_limit": "Recommended Limit",
+		"max_limit": "Max Limit",
+		"candidation_count": "Candidates",
+		"elected_by": "Elected By",
+		"council": "Council",
+		"end_time": "End Time",
+		"search_posts_placeholder": "Search posts...",
+		"no_posts_match": "No posts match your search",
+		"view_my_candidations": "View My Candidations",
+		"add_candidation": "Add Candidation",
+		"add_nomination": "Add Nomination",
+		"select_post": "Select post",
+		"candidation_error": "Failed to submit candidation",
+		"candidation_success": "Candidation submitted successfully!",
+		"nomination_error": "Failed to submit nomination",
+		"nomination_success": "Nomination submitted successfully!",
+		"nominee_name": "Nominee Name",
+		"nominee_email": "Nominee Email",
+		"motivation": "Motivation",
+		"election_limits": "Election Limits",
+		"ends_in": "Ends In",
+		"actions": "Actions",
+		"candidated_status": "Candidation Status",
+		"you_have_candidated": "You have candidated for this post",
+		"candidated_at": "Candidated at",
+		"remove_candidation": "Remove Candidation",
+		"elected_at_semester": "Elected At Semester",
+		"no_description": "No description available",
+		"my_candidations": {
+			"page_title": "My Candidations",
+			"page_description": "Here you can view and manage your election candidations"
+		},
+		"back_to_elections": "Back to Elections",
+		"no_candidations": "You have no candidations",
+		"delete_candidation_success": "Candidation deleted successfully",
+		"error_delete_candidation": "Failed to delete candidation",
+		"limits": "Limits",
+		"no_limit": "No limit",
+		"no_end_time": "No end time",
+		"election_table_description": "Here is a list of all posts open for nominations and candidations. The limits for how many people can be elected to each post are ordered by recommended limit first, followed by the max limit.",
+		"sub_election": "Election category"
+	},
+	"info_box": {
+		"title": "Details"
+	}
 }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -369,7 +369,8 @@
 		"contact": "please contact your local webmaster",
 		"quote": "You are not a subset of the set of all users with access to this page.",
 		"quote_author": "The wise Debianne server",
-		"button": "Back to homepage"
+		"button": "Back to homepage",
+		"error": "Failed to load permissions for unknown reasons."
 	},
 	"documents": {
 		"title": "Title",

--- a/src/locales/sv/main.json
+++ b/src/locales/sv/main.json
@@ -1,502 +1,502 @@
 {
-	"fsek": "F-sektionen",
-	"title": "Huvudsida",
-	"calendar": "Kalender",
-	"calendarText": "Här kan du se sektionens kalender med kommande evenemang. Klicka för att gå till stora kalendersidan och scrolla sedan ner för information om hur du lägger till detta i din egen kalenderapp.",
-	"welcome": "Välkommen till nya hemsidan för F-sektionen!",
-	"welcomeText": "Just nu är vi i en övergångsperiod till vår nya hemsida. Vi jobbar med att kontinuerligt förbättra design och funktionalitet, och lägga till saker som just nu saknas gentemot den gamla hemsidan. Den går fortfarande att använda på old.fsektionen.se. Eftersom vi dessutom har bytt ut servern och databasen är det nya och gamla systemet separerade: om du har gamla konton, lokalbokningar, inställningar, bilbokningar etc. så kommer de inte vara tillgängliga genom den nya webben och du kommer att behöva göra nya. OBS! Vi planerar att göra oss av med den gamla hemsidan helt inom en snar framtid, så försök att i största mån att använda den nya. Om du har några frågor eller synpunkter, tveka inte att kontakta spindel via spindelman@fsektionen.se.",
-	"oldWebsiteButton": "Det var bättre förr...",
-	"welcomeAdmin": "Om du anser att du borde ha någon form av administratörsåtkomst, försök klicka på knappen nedan, i navigeringsfältet eller gå till fsektionen.se/admin. Om du fortfarande inte har åtkomst, kontakta utskottsordförande.",
-	"adminButton": "Administrationssidan",
-	"registerButton": "Registrera nytt konto",
-	"newsTitle": "Nyheter",
-	"newsText": "Om du vill använda mer avancerad formattering, använd Mattermost som nyhetskanal tills vi har lagt till mer funktionalitet. Nyhetssidan stöder nu bilder!",
-	"cafeTitle": "Hilbert Café",
-	"cafeText": "Hilbert Café är en plats för studenter att träffas, studera och umgås. Här kommer du till slut hitta mer interaktiv information om caféet, dess öppettider och engagemang. Caféet har även en egen sida att tillgå, och du kan nu skriva upp dig på caféets arbetspass på en annan sida.",
-	"cafe_shift_button": "Skriv upp dig på ett arbetspass",
-	"cafe_page_button": "Huvudsidan för caféet",
-	"coolThing": "En häftig sak som distraherar dig från att se att sidan inte är klar än",
-	"back": "Tillbaka",
-	"faq": {
-		"self": "Frågor besvarade",
-		"q1": {
-			"question": "Kan jag logga in med mitt gamla konto?",
-			"answer": "Nej, eftersom vi bytt till en ny databas måste du skapa ett nytt konto, vilket du kan göra på fsektionen.se/register. Det finns många saker du inte har tillgång till innan du skapat ett konto, verifierat din mail och blivit verifierad som medlem."
-		},
-		"q2": {
-			"question": "Hur blir jag verifierad som medlem?",
-			"answer": "Skapa ett konto, verifiera din mejl och lägg till ditt Stil-ID (hi6122al-s) i användarinställningarna (kolla i övre högra hörnet). Efter detta måste du vänta på att vi ska se om du verkligen har medlemskap. I samband med terminsstart kan det ta längre tid än normalt. Om du känner att det tar för lång tid kan du kontakta din utskottsordförande, eller en fadder/föset under nollningen."
-		},
-		"q3": {
-			"question": "Vad har ni kvar att flytta över?",
-			"answer": "Det mesta finns redan överflyttat. För att läsa styrdokumenten i samlad form (de finns tillgängliga genom dokumentarkivet om du vet deras namn) eller använda motionsmaskinen kan du använda gamla hemsidan. Vi jobbar så hårt vi kan för att allt ska finnas på nya hemsidan 🧡."
-		},
-		"q4": {
-			"question": "Hjälp! Jag har inga av mina gamla adminrättigheter!",
-			"answer": "Vänta eller kontakta ditt utskottsordförande och be dem att återställa dina rättigheter."
-		},
-		"q5": {
-			"question": "Jag har problem med att anmäla mig till evenemang, visa galleriet eller andra saker!??",
-			"answer": "Vi hindrar icke-medlemmar och användare utan verifierade mailadresser från att använda många av våra tjänster. Kontrollera följande: \n\nAtt du verkligen har verifierat ditt konto (prova fsektionen.se/verify). \nAtt du är registrerad som medlem. (kolla i kontoinställningar för att kontrollera båda dessa!) \nAtt du är inloggad på rätt konto och inte har skapat flera konton, till exempel ett med din studentmail och ett annat med din privata mail. Om du har mer än ett konto och vill bli av med det dåliga, kontakta spindelman@fsektionen.se via mailet för det konto du vill ta bort."
-		}
-	},
-	"next": "Nästa",
-	"previous": "Föregående",
-	"page": "Sida",
-	"navbar": {
-		"sektionen": {
-			"self": "Sektionen",
-			"about": {
-				"self": "Om oss",
-				"desc": "Välkommen till vår sektion - lär känna oss och våra värderingar.",
-				"href": "/about"
-			},
-			"news": {
-				"self": "Nyheter",
-				"desc": "Håll dig uppdaterad med de senaste nyheterna från sektionen.",
-				"href": "/news"
-			},
-			"calendar": {
-				"self": "Kalender",
-				"desc": "Håll koll på kommande evenemang och aktiviteter.",
-				"href": "/calendar"
-			},
-			"councils": {
-				"self": "Utskott",
-				"desc": "Utforska våra utskotts arbete och engagemang.",
-				"href": "/councils"
-			},
-			"documents": {
-				"self": "Dokument",
-				"desc": "Bläddra bland dokument som producerats av sektionen.",
-				"href": "/documents"
-			},
-			"privacy": {
-				"self": "Sekretesspolicy",
-				"desc": "Läs mer om hur vi hanterar dina personuppgifter.",
-				"href": "/privacy"
-			},
-			"nollning": {
-				"self": "Nollning",
-				"desc": "Varmt välkommen till F-sektionen och grattis till din plats på civilingenjörsprogrammet i teknisk fysik, teknisk matematik eller teknisk nanovetenskap!",
-				"href": "/nollning"
-			}
-		},
-		"engage": {
-			"self": "Engagera dig",
-			"cafe": {
-				"self": "Hilbert Café",
-				"desc": "Träffa likasinnade och njut av en avslappnad atmosfär (och gratis lunch!).",
-				"href": "/cafe"
-			},
-			"positions": {
-				"self": "Bli funktionär",
-				"desc": "Vill du engagera dig i något utskott? Se hit!",
-				"href": "/positions"
-			},
-			"nollningsvol": {
-				"self": "Nollningsvolontärer",
-				"desc": "Hjälp oss att välkomna nya studenter och ge dem en bra start på studierna!",
-				"href": "/nollningsvolontar"
-			},
-			"elections": {
-				"self": "Val",
-				"desc": "Sök till sektionens poster!",
-				"href": "/election"
-			},
-			"projects": {
-				"self": "Projekt",
-				"desc": "Upptäck spännande initiativ och samarbeten inom sektionen.",
-				"href": "/projects"
-			},
-			"freja": {
-				"self": "FREJA",
-				"desc": "FREJA är en fristående organisation för dig som är kvinna eller icke-binär.",
-				"href": "https://www.frejalth.se/"
-			}
-		},
-		"services": {
-			"self": "Tjänster",
-			"car": {
-				"self": "Bilbokning",
-				"desc": "Boka bilen enkelt och smidigt för dina resor och behov.",
-				"href": "/car"
-			},
-			"rooms": {
-				"self": "Lokalbokning",
-				"desc": "Boka sektionens tre rum i Matematikhuset för personliga evenemang eller utskottsmöten.",
-				"href": "/room-bookings"
-			},
-			"tools": {
-				"self": "Verktygsutlåning",
-				"desc": "Låna sektionens verktyg för dina projekt.",
-				"href": "/tools"
-			},
-			"specialrooms": {
-				"self": "Stillarum/Bönerum",
-				"desc": "Hitta en lugn plats för reflektion eller bön.",
-				"href": "/stillarum"
-			},
-			"gallery": {
-				"self": "Galleri",
-				"desc": "Utforska vårt bildgalleri och få en inblick i sektionens historia.",
-				"href": "/gallery"
-			},
-			"calendar": {
-				"self": "Kalender",
-				"desc": "Håll koll på kommande evenemang och aktiviteter.",
-				"href": "/calendar"
-			},
-			"songs": {
-				"self": "Sångbok",
-				"desc": "Bläddra bland sångerna som sjungs på sektionens evenemang.",
-				"href": "/songs"
-			}
-		},
-		"companies": {
-			"self": "Företag",
-			"aboutCompany": {
-				"self": "Om F-sektionen",
-				"desc": "Upptäck vilka vi är och de program vi representerar.",
-				"href": "/foretag/om"
-			},
-			"offerings": {
-				"self": "Våra erbjudanden",
-				"desc": "Utforska förslag på samarbeten för att nå ut till våra medlemmar.",
-				"href": "/foretag/vi-erbjuder"
-			},
-			"farad": {
-				"self": "Farad",
-				"desc": "Läs mer om F-sektionens arbetsmarknadsmässa.",
-				"href": "https://farad.nu"
-			},
-			"contact": {
-				"self": "Företagskontakt",
-				"desc": "Kontakta oss för affärsförfrågningar och samarbeten.",
-				"href": "/contact#naringslivsutskottet"
-			}
-		},
-		"contact": {
-			"self": "Kontakt",
-			"contactPage": {
-				"self": "Kontaktsida",
-				"desc": "Här hittar du all information du behöver för att nå oss.",
-				"href": "/contact"
-			},
-			"ordf": {
-				"self": "Ordförande",
-				"desc": "För frågor om organisationen.",
-				"href": "/contact#ordf"
-			},
-			"web": {
-				"self": "Webbansvarig",
-				"desc": "För frågor om vår webbplats eller app.",
-				"href": "/contact#webmaster"
-			},
-			"anonymousForm": {
-				"self": "Anonymt kontaktformulär",
-				"desc": "För hemlig feedback eller bekymmer.",
-				"href": "https://docs.google.com/forms/d/e/1FAIpQLSdZdPl14DkdlZCKS3jzO59-FvVi2ug9nYer1jhYgERanbwHoQ/viewform"
-			},
-			"klaga": {
-				"self": "Klagomål",
-				"desc": "Skicka ett anonymt klagomål, en åsikt eller ändringsförslag till TLTH.",
-				"href": "https://www.tlth.se/klaga"
-			}
-		},
-		"booking": "Bokningar",
-		"documents": "Dokument",
-		"account-settings": "Kontoinställningar",
-		"logout": "Logga ut",
-		"logoutError": "Utloggning misslyckades. Försök igen senare.",
-		"verify": "Verifiera e-post",
-		"guild-meeting": "Sektionsmöte"
-	},
-	"footer": {
-		"contact": "Kontakt",
-		"emergencycontact": "Nödkontakt",
-		"companies": "För företag",
-		"webansvar": "Webbansvarig",
-		"ansvar": "Ansvarig utgivare",
-		"copyright": "F-sektionen. Alla rättigheter förvarade i superposition i ogenomtränglig låda."
-	},
-	"login": {
-		"login": "Logga in",
-		"invalid-email-or-password": "Fel e-postadress eller lösenord",
-		"email": "E-postadress",
-		"password": "Lösenord",
-		"title": "Logga in",
-		"registerPrompt": "Har du inget konto? Registrera dig här.",
-		"forgotPassword": "Glömt lösenord?",
-		"forgotEmailLabel": "Ange din e-post för att återställa lösenord",
-		"forgotSubmit": "Skicka återställningslänk",
-		"forgotLoading": "Skickar...",
-		"forgotSuccess": "Om din e-post finns så har en återställningslänk skickats till den.",
-		"backToLogin": "Tillbaka till inloggning",
-		"invalidEmailFormat": "Ogiltigt e-postformat"
-	},
-	"news": {
-		"self": "Nyheter",
-		"by": "Skriven av: ",
-		"pinned": "Fastnålad",
-		"see_all": "Se alla nyheter",
-		"read_more": "Läs mer"
-	},
-	"verifyMail": {
-		"loading": "Verifierar din e-post...",
-		"success": "E-postverifiering lyckades!",
-		"error": "E-postverifiering misslyckades. Länken kan ha gått ut eller varit ogiltig, eller så har du redan verifierat din e-post. Du kan gå till fsektionen.se/verify utan token för att få en ny länk.",
-		"goHome": "Gå till startsidan",
-		"noToken": "Du kan begära en ny verifieringslänk genom att ange din e-post nedan. (om du kom hit från ett mejl, kontrollera att du kopierade hela länken.)",
-		"requestSuccess": "En verifieringslänk har skickats till din e-postadress om den finns registrerad.",
-		"requestError": "Det gick inte att skicka verifieringsmejlet. Försök igen senare.",
-		"emailPlaceholder": "Ange din e-post",
-		"requestNew": "Begär ny verifieringslänk"
-	},
-	"verifyReminder": {
-		"message": "Ditt konto har inte en verifierad e-post. Du MÅSTE verifiera din e-post innan hemsidan kommer att fungera korrekt.",
-		"go": "Verifiera nu"
-	},
-	"memberBanner": {
-		"message": "Ditt konto är inte registrerat som medlem i F-sektionen. Du kan inte göra något åt detta själv. Kontakta din utskottsordförande eller annan ansvarig person inom sektionen för att bli registrerad som medlem. Innan detta kommer du inte kunna använda många av sektionens tjänster."
-	},
-	"reset-password": {
-		"title": "Återställ lösenord",
-		"password": "Nytt lösenord",
-		"retype-password": "Upprepa lösenord",
-		"passwords-do-not-match": "Lösenorden är olika",
-		"reset-password": "Återställ lösenord",
-		"resetting": "Återställer ditt lösenord...",
-		"reset-success": "Ditt lösenord har återställts!",
-		"goHome": "Gå till startsidan",
-		"reset-error": "Återställning av lösenord misslyckades.",
-		"invalid-reset-token": "Ogiltig eller saknad återställningslänk."
-	},
-	"register": {
-		"title": "Registrera ett konto",
-		"email": "E-postadress",
-		"password": "Lösenord",
-		"confirmPassword": "Bekräfta lösenord",
-		"firstName": "Förnamn",
-		"lastName": "Efternamn",
-		"telephone": "Telefonnummer med landskod (+46)",
-		"startYear": "Startår (valfritt)",
-		"submit": "Registrera",
-		"loginPrompt": "Har du redan ett konto? Logga in här.",
-		"loading": "Registrerar...",
-		"error": "Registreringen misslyckades. Kontrollera dina uppgifter och försök igen.",
-		"verifyError": "Användaren registrerades, men det gick inte att skicka verifieringsmail. Försök igen senare.",
-		"success": "Registreringen lyckades! Kontrollera din e-post för att verifiera ditt konto.",
-		"goLogin": "Gå till inloggning",
-		"passwordMismatch": "Lösenorden matchar inte. Försök igen.",
-		"passwordNoNumber": "Lösenordet måste innehålla minst ett nummer.",
-		"passwordNoLetter": "Lösenordet måste innehålla minst en bokstav (som inte är åäö).",
-		"startYearInvalid": "Startåret måste vara mellan 1960 och nuvarande år.",
-		"emailInvalid": "Ogiltig e-postadress",
-		"passwordShort": "Lösenordet måste vara minst 8 tecken",
-		"firstNameRequired": "Förnamn krävs",
-		"lastNameRequired": "Efternamn krävs",
-		"telephoneNumberRequired": "Telefonnummer krävs",
-		"gdprLabel": "Jag har läst och godkänner",
-		"privacyPolicy": "sekretesspolicyn.",
-		"gdprRequired": "Du måste godkänna sekretesspolicyn för att registrera dig."
-	},
-	"car-booking": {
-		"title": "Bilbokning",
-		"description-title": "FAQ och regler",
-		"description": "Som medlem kan du boka sektionens bil för personliga och sektionrelaterade behov. Om du är administratör kan du hantera bokningar <0>här</0> istället. Genom att boka bilen godkänner du att följa reglerna som finns <1>här</1>.",
-		"faq": {
-			"title": "Vanliga frågor",
-			"q1": "Vem kan boka bilen?",
-			"a1": "Alla medlemmar i sektionen kan boka bilen.",
-			"q2": "Biluthyrning under sommaren?",
-			"a2": "Eftersom verksamheten är pausad under sommaren är det inte lätt att hyra sektionsbilen. Kontakta styrelsen på board (at) fsektionen.se för att höra om det går att lösa.",
-			"q3": "Hur många får plats i bilen?",
-			"a3": "Bilen har plats för upp till 7 personer, inklusive föraren.",
-			"q4": "Hur stort är lastutrymmet i bilen?",
-			"a4": "Bagageutrymmet (med nedfällda baksäten) är cirka (med reservation för att det inte är en perfekt rektangel) 190 cm djupt, 130 cm brett och 80 cm högt.",
-			"q5": "Vad kostar det att hyra bilen?",
-			"a5": "Medlemmar i F-sektionen betalar en startavgift på 150 kr. Startavgiften inkluderar 20 kilometer, därefter kostar det 5 kr per påbörjad kilometer.",
-			"q6": "Vad betyder färgerna?",
-			"a6": "Olika färger visar status och ägarskap för varje bokning. En administratör (bilförmannen) måste bekräfta bokningar utanför ordinarie tider. Färgerna har följande mening: \n- Ljusorange färg innebär att det är din bokning, men den är inte bekräftad.\n- Mörkorange färg innebär att det är din bokning och den är bekräftad. \n- Grön färg markerar någon annans bekräftade bokning.\n- Gul färg visar någon annans obekräftade bokning.\n- Ljusblå färg används för bokningar som lagts till lokalt men inte hämtats från servern än. Ser du blått kan något ha gått fel, ladda då om sidan.",
-			"q7": "Jag har fler frågor!",
-			"a7": "Du kan kontakta bilförmannen bland annat genom <0>kontaktsidan</0>. Be gärna bilförmannen eller spindelmännen att lägga till frågan med svar här."
-		}
-	},
-	"room-booking": {
-		"title": "Lokalbokning",
-		"description-title": "FAQ och regler",
-		"description": "Som medlem måste du kontakta en administratör om du vill boka ett rum, men du kan se alla rumsbokningar här. Om du är administratör kan du boka rum <0>här</0> istället.",
-		"faq": {
-			"title": "Vanliga frågor",
-			"q1": "Vem kan boka lokalerna?",
-			"a1": "Endast administratörer kan boka lokalerna. Om du är medlem kan du kontakta en person från nämnden eller ditt utskottsordförande för att be dem boka ett rum.",
-			"q2": "Jag har fler frågor!",
-			"a2": "Det finns ingen huvudansvarig för lokalbokning, kontakta prylmästaren eller styrelsen om du undrar något. Du kan också be dem att lägga till frågan med svar här."
-		}
-	},
-	"loading": {
-		"basic": "Laddar innehåll...",
-		"flavor_1": "Checkar in på Hilberts hotel...",
-		"flavor_2": "Hittar determinanten...",
-		"flavor_3": "Spelar moose game...",
-		"flavor_4": "Räknar ut sista siffran i π...",
-		"flavor_5": "Jäser mer Hilbeaux...",
-		"flavor_6": "Polerar pixlar...",
-		"flavor_7": "Räknar till oändligheten...",
-		"flavor_8": "Skapar ännu en gandalftenta...",
-		"flavor_9": "Bevisar Riemannhypotesen...",
-		"flavor_10": "Byter koordinatsystem...",
-		"flavor_11": "Preppar Hilbertmackor...",
-		"flavor_12": "Väntar på Ladokavisering...",
-		"flavor_13": "Väntar tills impulssvaret dör ut...",
-		"flavor_14": "Skriver motionssvar...",
-		"flavor_15": "Kompilerar LaTeX...",
-		"flavor_16": "Homogeniserar randvillkor...",
-		"error_occurred": "Ett fel uppstod:",
-		"no_error_message": "Inget felmeddelande tillgängligt.",
-		"network_error": "Ett nätverksfel uppstod. Kontrollera din anslutning.",
-		"unauthorized": "Du är inte auktoriserad att se detta innehåll. Logga in."
-	},
-	"cookieConsent": {
-		"message": "Vi använder cookies för att förbättra din upplevelse på vår webbplats (autentisering, språk och mer). Genom att fortsätta använda webbplatsen godkänner du vår användning av cookies.",
-		"accept": "Okej"
-	},
-	"permission-wall": {
-		"stop": "Stopp",
-		"subtitle": "Sakta i backarna!",
-		"message": "Du har inte behörighet att se denna sida. Om du tror att något är fel, ",
-		"contact": "kontakta din lokala spindelman.",
-		"quote": "Här har vi begått lite småillegala saker längs vägen.",
-		"quote_author": "Mikael \"Micke P\" Persson Sundqvist",
-		"button": "Tillbaka till hemsidan"
-	},
-	"documents": {
-		"title": "Titel",
-		"created_at": "Skapad",
-		"private_explanation": "Endast medlemmar",
-		"author": "Författare",
-		"category": "Kategori",
-		"view": "Visa",
-		"view_doc": "Visa dokumentet",
-		"page_title": "Dokument",
-		"description": "Här kan du hitta och läsa dokument som delas inom sektionen. Vissa dokument är markerade för att endast vara synliga för medlemmar.",
-		"search_title": "Sök efter titel eller kategori",
-		"file_name": "Filnamn",
-		"updated_at": "Uppdaterad",
-		"is_private": "Visas endast för medlemmar"
-	},
-	"guild_meeting": {
-		"important_dates": "Viktiga datum"
-	},
-	"yes": "Ja",
-	"no": "Nej",
-	"not_found": "Hittades inte",
-	"description": "Beskrivning",
-	"event_signup": {
-		"title": "Eventanmälan",
-		"priority": "Prioritet",
-		"select_priority": "Välj prioritetsgrupp att anmäla dig med",
-		"group_name": "Gruppnamn",
-		"group_name_placeholder": "Ange gruppnamn (valfritt)",
-		"drink_package": {
-			"title": "Dryckespaket",
-			"none": "Inget",
-			"alcohol_free": "Alkoholfritt",
-			"alcohol": "Alkohol"
-		},
-		"select_drink_package": "Välj dryckespaket",
-		"button": "Anmäl dig",
-		"update_button": "Uppdatera anmälan",
-		"edit_button": "Redigera",
-		"signoff_button": "Avanmäl",
-		"success_create": "Anmälan lyckades!",
-		"success_update": "Anmälan uppdaterad!",
-		"success_signoff": "Du har avanmält dig från eventet.",
-		"error_create": "Kunde inte anmäla dig: {{error}}",
-		"error_update": "Kunde inte uppdatera anmälan: {{error}}",
-		"error_signoff": "Kunde inte avanmäla dig: {{error}}",
-		"unknown_error": "Okänt fel.",
-		"not_found": "Du är inte anmäld till detta event.",
-		"user": "Användare",
-		"status": "Status",
-		"confirmed": "Bekräftad",
-		"pending": "Väntar på bekräftelse",
-		"period_passed_signed_up": "Anmälningsperioden är slut. Om du vill ändra eller dra tillbaka din anmälan, kontakta eventansvarig.",
-		"period_passed_not_signed_up": "Anmälningsperioden är slut. Du kan inte längre anmäla dig. Om du har några frågor, vänligen kontakta eventansvarig.",
-		"food_preferences_title": "Matpreferenser",
-		"food_preferences_explainer": "Detta är dina sparade matpreferenser. Om något inte ser rätt ut kan du uppdatera dem i dina kontoinställningar.",
-		"standard_food_preferences": "Standardpreferenser:",
-		"other_food_preferences": "Övriga preferenser:",
-		"none": "Inga",
-		"signup_not_used": "Du kan inte anmäla dig till detta evenemang eftersom eventet inte använder systemet med anmälan för att delta."
-	},
-	"songs": {
-		"by": "Av",
-		"melody": "Melodi",
-		"category": "Kategori",
-		"views": "Visningar",
-		"title": "Sånger",
-		"description_subtitle": "Bläddra och sjung med i vår samling av sånger.",
-		"search_placeholder": "Sök sånger..."
-	},
-	"gallery": {
-		"title": "Galleri",
-		"select_year": "Välj år",
-		"photographers": "Fotografer"
-	},
-	"post": "Post",
-	"elections": {
-		"ended": "Avslutad",
-		"left": "kvar",
-		"day": "{{count}} dag(ar)",
-		"hour": "{{count}} h",
-		"min": "{{count}} min",
-		"no_visible_election": "Inget synligt val tillgängligt",
-		"post_name": "Postnamn",
-		"recommended_limit": "Rekommenderad gräns",
-		"max_limit": "Max gräns",
-		"candidation_count": "Kandidater",
-		"elected_by": "Vald av",
-		"council": "Utskott",
-		"end_time": "Sluttid",
-		"search_posts_placeholder": "Sök poster...",
-		"no_posts_match": "Inga poster matchar din sökning",
-		"view_my_candidations": "Visa mina kandidaturer",
-		"add_candidation": "Lägg till kandidatur",
-		"add_nomination": "Lägg till nominering",
-		"select_post": "Välj post",
-		"candidation_error": "Misslyckades att skapa kandidatur",
-		"candidation_success": "Kandidatur skapades!",
-		"nomination_error": "Misslyckades att skicka nominering",
-		"nomination_success": "Nominering skickad!",
-		"nominee_name": "Nominerade personens namn",
-		"nominee_email": "Nominerade personens e-post",
-		"motivation": "Motivering",
-		"election_limits": "Valgränser",
-		"ends_in": "Slutar om",
-		"actions": "Åtgärder",
-		"candidated_status": "Kandidaturstatus",
-		"you_have_candidated": "Du har kandiderat för denna post",
-		"candidated_at": "Kandiderade",
-		"remove_candidation": "Ta bort kandidatur",
-		"elected_at_semester": "Vald under termin",
-		"no_description": "Ingen beskrivning tillgänglig",
-		"my_candidations": {
-			"page_title": "Mina kandidaturer",
-			"page_description": "Här kan du se och hantera dina valkandidaturer"
-		},
-		"back_to_elections": "Tillbaka till val",
-		"no_candidations": "Du har inga kandidaturer",
-		"delete_candidation_success": "Kandidatur borttagen framgångsrikt",
-		"error_delete_candidation": "Misslyckades att ta bort kandidatur",
-		"limits": "Gränser",
-		"no_limit": "Ingen gräns",
-		"no_end_time": "Ingen sluttid",
-		"election_table_description": "Här är en lista över alla poster som är öppna för nomineringar och kandidaturer. Gränserna för hur många som kan bli valda till varje post är ordnade enligt rekommenderad gräns först, följt av maxgränsen.",
-		"sub_election": "Valkategori"
-	},
-	"info_box": {
-		"title": "Detaljer"
-	}
+  "fsek": "F-sektionen",
+  "title": "Huvudsida",
+  "calendar": "Kalender",
+  "calendarText": "Här kan du se sektionens kalender med kommande evenemang. Klicka för att gå till stora kalendersidan och scrolla sedan ner för information om hur du lägger till detta i din egen kalenderapp.",
+  "welcome": "Välkommen till nya hemsidan för F-sektionen!",
+  "welcomeText": "Just nu är vi i en övergångsperiod till vår nya hemsida. Vi jobbar med att kontinuerligt förbättra design och funktionalitet, och lägga till saker som just nu saknas gentemot den gamla hemsidan. Den går fortfarande att använda på old.fsektionen.se. Eftersom vi dessutom har bytt ut servern och databasen är det nya och gamla systemet separerade: om du har gamla konton, lokalbokningar, inställningar, bilbokningar etc. så kommer de inte vara tillgängliga genom den nya webben och du kommer att behöva göra nya. OBS! Vi planerar att göra oss av med den gamla hemsidan helt inom en snar framtid, så försök att i största mån att använda den nya. Om du har några frågor eller synpunkter, tveka inte att kontakta spindel via spindelman@fsektionen.se.",
+  "oldWebsiteButton": "Det var bättre förr...",
+  "welcomeAdmin": "Om du anser att du borde ha någon form av administratörsåtkomst, försök klicka på knappen nedan, i navigeringsfältet eller gå till fsektionen.se/admin. Om du fortfarande inte har åtkomst, kontakta utskottsordförande.",
+  "adminButton": "Administrationssidan",
+  "registerButton": "Registrera nytt konto",
+  "newsTitle": "Nyheter",
+  "newsText": "Om du vill använda mer avancerad formattering, använd Mattermost som nyhetskanal tills vi har lagt till mer funktionalitet. Nyhetssidan stöder nu bilder!",
+  "cafeTitle": "Hilbert Café",
+  "cafeText": "Hilbert Café är en plats för studenter att träffas, studera och umgås. Här kommer du till slut hitta mer interaktiv information om caféet, dess öppettider och engagemang. Caféet har även en egen sida att tillgå, och du kan nu skriva upp dig på caféets arbetspass på en annan sida.",
+  "cafe_shift_button": "Skriv upp dig på ett arbetspass",
+  "cafe_page_button": "Huvudsidan för caféet",
+  "coolThing": "En häftig sak som distraherar dig från att se att sidan inte är klar än",
+  "back": "Tillbaka",
+  "faq": {
+    "self": "Frågor besvarade",
+    "q1": {
+      "question": "Kan jag logga in med mitt gamla konto?",
+      "answer": "Nej, eftersom vi bytt till en ny databas måste du skapa ett nytt konto, vilket du kan göra på fsektionen.se/register. Det finns många saker du inte har tillgång till innan du skapat ett konto, verifierat din mail och blivit verifierad som medlem."
+    },
+    "q2": {
+      "question": "Hur blir jag verifierad som medlem?",
+      "answer": "Skapa ett konto, verifiera din mejl och lägg till ditt Stil-ID (hi6122al-s) i användarinställningarna (kolla i övre högra hörnet). Efter detta måste du vänta på att vi ska se om du verkligen har medlemskap. I samband med terminsstart kan det ta längre tid än normalt. Om du känner att det tar för lång tid kan du kontakta din utskottsordförande, eller en fadder/föset under nollningen."
+    },
+    "q3": {
+      "question": "Vad har ni kvar att flytta över?",
+      "answer": "Det mesta finns redan överflyttat. För att läsa styrdokumenten i samlad form (de finns tillgängliga genom dokumentarkivet om du vet deras namn) eller använda motionsmaskinen kan du använda gamla hemsidan. Vi jobbar så hårt vi kan för att allt ska finnas på nya hemsidan 🧡."
+    },
+    "q4": {
+      "question": "Hjälp! Jag har inga av mina gamla adminrättigheter!",
+      "answer": "Vänta eller kontakta ditt utskottsordförande och be dem att återställa dina rättigheter."
+    },
+    "q5": {
+      "question": "Jag har problem med att anmäla mig till evenemang, visa galleriet eller andra saker!??",
+      "answer": "Vi hindrar icke-medlemmar och användare utan verifierade mailadresser från att använda många av våra tjänster. Kontrollera följande: \n\nAtt du verkligen har verifierat ditt konto (prova fsektionen.se/verify). \nAtt du är registrerad som medlem. (kolla i kontoinställningar för att kontrollera båda dessa!) \nAtt du är inloggad på rätt konto och inte har skapat flera konton, till exempel ett med din studentmail och ett annat med din privata mail. Om du har mer än ett konto och vill bli av med det dåliga, kontakta spindelman@fsektionen.se via mailet för det konto du vill ta bort."
+    }
+  },
+  "next": "Nästa",
+  "previous": "Föregående",
+  "page": "Sida",
+  "navbar": {
+    "sektionen": {
+      "self": "Sektionen",
+      "about": {
+        "self": "Om oss",
+        "desc": "Välkommen till vår sektion - lär känna oss och våra värderingar.",
+        "href": "/about"
+      },
+      "news": {
+        "self": "Nyheter",
+        "desc": "Håll dig uppdaterad med de senaste nyheterna från sektionen.",
+        "href": "/news"
+      },
+      "calendar": {
+        "self": "Kalender",
+        "desc": "Håll koll på kommande evenemang och aktiviteter.",
+        "href": "/calendar"
+      },
+      "councils": {
+        "self": "Utskott",
+        "desc": "Utforska våra utskotts arbete och engagemang.",
+        "href": "/councils"
+      },
+      "documents": {
+        "self": "Dokument",
+        "desc": "Bläddra bland dokument som producerats av sektionen.",
+        "href": "/documents"
+      },
+      "privacy": {
+        "self": "Sekretesspolicy",
+        "desc": "Läs mer om hur vi hanterar dina personuppgifter.",
+        "href": "/privacy"
+      },
+      "nollning": {
+        "self": "Nollning",
+        "desc": "Varmt välkommen till F-sektionen och grattis till din plats på civilingenjörsprogrammet i teknisk fysik, teknisk matematik eller teknisk nanovetenskap!",
+        "href": "/nollning"
+      }
+    },
+    "engage": {
+      "self": "Engagera dig",
+      "cafe": {
+        "self": "Hilbert Café",
+        "desc": "Träffa likasinnade och njut av en avslappnad atmosfär (och gratis lunch!).",
+        "href": "/cafe"
+      },
+      "positions": {
+        "self": "Bli funktionär",
+        "desc": "Vill du engagera dig i något utskott? Se hit!",
+        "href": "/positions"
+      },
+      "nollningsvol": {
+        "self": "Nollningsvolontärer",
+        "desc": "Hjälp oss att välkomna nya studenter och ge dem en bra start på studierna!",
+        "href": "/nollningsvolontar"
+      },
+      "elections": {
+        "self": "Val",
+        "desc": "Sök till sektionens poster!",
+        "href": "/election"
+      },
+      "projects": {
+        "self": "Projekt",
+        "desc": "Upptäck spännande initiativ och samarbeten inom sektionen.",
+        "href": "/projects"
+      },
+      "freja": {
+        "self": "FREJA",
+        "desc": "FREJA är en fristående organisation för dig som är kvinna eller icke-binär.",
+        "href": "https://www.frejalth.se/"
+      }
+    },
+    "services": {
+      "self": "Tjänster",
+      "car": {
+        "self": "Bilbokning",
+        "desc": "Boka bilen enkelt och smidigt för dina resor och behov.",
+        "href": "/car"
+      },
+      "rooms": {
+        "self": "Lokalbokning",
+        "desc": "Boka sektionens tre rum i Matematikhuset för personliga evenemang eller utskottsmöten.",
+        "href": "/room-bookings"
+      },
+      "tools": {
+        "self": "Verktygsutlåning",
+        "desc": "Låna sektionens verktyg för dina projekt.",
+        "href": "/tools"
+      },
+      "specialrooms": {
+        "self": "Stillarum/Bönerum",
+        "desc": "Hitta en lugn plats för reflektion eller bön.",
+        "href": "/stillarum"
+      },
+      "gallery": {
+        "self": "Galleri",
+        "desc": "Utforska vårt bildgalleri och få en inblick i sektionens historia.",
+        "href": "/gallery"
+      },
+      "calendar": {
+        "self": "Kalender",
+        "desc": "Håll koll på kommande evenemang och aktiviteter.",
+        "href": "/calendar"
+      },
+      "songs": {
+        "self": "Sångbok",
+        "desc": "Bläddra bland sångerna som sjungs på sektionens evenemang.",
+        "href": "/songs"
+      }
+    },
+    "companies": {
+      "self": "Företag",
+      "aboutCompany": {
+        "self": "Om F-sektionen",
+        "desc": "Upptäck vilka vi är och de program vi representerar.",
+        "href": "/foretag/om"
+      },
+      "offerings": {
+        "self": "Våra erbjudanden",
+        "desc": "Utforska förslag på samarbeten för att nå ut till våra medlemmar.",
+        "href": "/foretag/vi-erbjuder"
+      },
+      "farad": {
+        "self": "Farad",
+        "desc": "Läs mer om F-sektionens arbetsmarknadsmässa.",
+        "href": "https://farad.nu"
+      },
+      "contact": {
+        "self": "Företagskontakt",
+        "desc": "Kontakta oss för affärsförfrågningar och samarbeten.",
+        "href": "/contact#naringslivsutskottet"
+      }
+    },
+    "contact": {
+      "self": "Kontakt",
+      "contactPage": {
+        "self": "Kontaktsida",
+        "desc": "Här hittar du all information du behöver för att nå oss.",
+        "href": "/contact"
+      },
+      "ordf": {
+        "self": "Ordförande",
+        "desc": "För frågor om organisationen.",
+        "href": "/contact#ordf"
+      },
+      "web": {
+        "self": "Webbansvarig",
+        "desc": "För frågor om vår webbplats eller app.",
+        "href": "/contact#webmaster"
+      },
+      "anonymousForm": {
+        "self": "Anonymt kontaktformulär",
+        "desc": "För hemlig feedback eller bekymmer.",
+        "href": "https://docs.google.com/forms/d/e/1FAIpQLSdZdPl14DkdlZCKS3jzO59-FvVi2ug9nYer1jhYgERanbwHoQ/viewform"
+      },
+      "klaga": {
+        "self": "Klagomål",
+        "desc": "Skicka ett anonymt klagomål, en åsikt eller ändringsförslag till TLTH.",
+        "href": "https://www.tlth.se/klaga"
+      }
+    },
+    "booking": "Bokningar",
+    "documents": "Dokument",
+    "account-settings": "Kontoinställningar",
+    "logout": "Logga ut",
+    "logoutError": "Utloggning misslyckades. Försök igen senare.",
+    "verify": "Verifiera e-post",
+    "guild-meeting": "Sektionsmöte"
+  },
+  "footer": {
+    "contact": "Kontakt",
+    "emergencycontact": "Nödkontakt",
+    "companies": "För företag",
+    "webansvar": "Webbansvarig",
+    "ansvar": "Ansvarig utgivare",
+    "copyright": "F-sektionen. Alla rättigheter förvarade i superposition i ogenomtränglig låda."
+  },
+  "login": {
+    "login": "Logga in",
+    "invalid-email-or-password": "Fel e-postadress eller lösenord",
+    "email": "E-postadress",
+    "password": "Lösenord",
+    "title": "Logga in",
+    "registerPrompt": "Har du inget konto? Registrera dig här.",
+    "forgotPassword": "Glömt lösenord?",
+    "forgotEmailLabel": "Ange din e-post för att återställa lösenord",
+    "forgotSubmit": "Skicka återställningslänk",
+    "forgotLoading": "Skickar...",
+    "forgotSuccess": "Om din e-post finns så har en återställningslänk skickats till den.",
+    "backToLogin": "Tillbaka till inloggning",
+    "invalidEmailFormat": "Ogiltigt e-postformat"
+  },
+  "news": {
+    "self": "Nyheter",
+    "by": "Skriven av: ",
+    "pinned": "Fastnålad",
+    "see_all": "Se alla nyheter",
+    "read_more": "Läs mer"
+  },
+  "verifyMail": {
+    "loading": "Verifierar din e-post...",
+    "success": "E-postverifiering lyckades!",
+    "error": "E-postverifiering misslyckades. Länken kan ha gått ut eller varit ogiltig, eller så har du redan verifierat din e-post. Du kan gå till fsektionen.se/verify utan token för att få en ny länk.",
+    "goHome": "Gå till startsidan",
+    "noToken": "Du kan begära en ny verifieringslänk genom att ange din e-post nedan. (om du kom hit från ett mejl, kontrollera att du kopierade hela länken.)",
+    "requestSuccess": "En verifieringslänk har skickats till din e-postadress om den finns registrerad.",
+    "requestError": "Det gick inte att skicka verifieringsmejlet. Försök igen senare.",
+    "emailPlaceholder": "Ange din e-post",
+    "requestNew": "Begär ny verifieringslänk"
+  },
+  "verifyReminder": {
+    "message": "Ditt konto har inte en verifierad e-post. Du MÅSTE verifiera din e-post innan hemsidan kommer att fungera korrekt.",
+    "go": "Verifiera nu"
+  },
+  "memberBanner": {
+    "message": "Ditt konto är inte registrerat som medlem i F-sektionen. Du kan inte göra något åt detta själv. Kontakta din utskottsordförande eller annan ansvarig person inom sektionen för att bli registrerad som medlem. Innan detta kommer du inte kunna använda många av sektionens tjänster."
+  },
+  "reset-password": {
+    "title": "Återställ lösenord",
+    "password": "Nytt lösenord",
+    "retype-password": "Upprepa lösenord",
+    "passwords-do-not-match": "Lösenorden är olika",
+    "reset-password": "Återställ lösenord",
+    "resetting": "Återställer ditt lösenord...",
+    "reset-success": "Ditt lösenord har återställts!",
+    "goHome": "Gå till startsidan",
+    "reset-error": "Återställning av lösenord misslyckades.",
+    "invalid-reset-token": "Ogiltig eller saknad återställningslänk."
+  },
+  "register": {
+    "title": "Registrera ett konto",
+    "email": "E-postadress",
+    "password": "Lösenord",
+    "confirmPassword": "Bekräfta lösenord",
+    "firstName": "Förnamn",
+    "lastName": "Efternamn",
+    "telephone": "Telefonnummer med landskod (+46)",
+    "startYear": "Startår (valfritt)",
+    "submit": "Registrera",
+    "loginPrompt": "Har du redan ett konto? Logga in här.",
+    "loading": "Registrerar...",
+    "error": "Registreringen misslyckades. Kontrollera dina uppgifter och försök igen.",
+    "verifyError": "Användaren registrerades, men det gick inte att skicka verifieringsmail. Försök igen senare.",
+    "success": "Registreringen lyckades! Kontrollera din e-post för att verifiera ditt konto.",
+    "goLogin": "Gå till inloggning",
+    "passwordMismatch": "Lösenorden matchar inte. Försök igen.",
+    "passwordNoNumber": "Lösenordet måste innehålla minst ett nummer.",
+    "passwordNoLetter": "Lösenordet måste innehålla minst en bokstav (som inte är åäö).",
+    "startYearInvalid": "Startåret måste vara mellan 1960 och nuvarande år.",
+    "emailInvalid": "Ogiltig e-postadress",
+    "passwordShort": "Lösenordet måste vara minst 8 tecken",
+    "firstNameRequired": "Förnamn krävs",
+    "lastNameRequired": "Efternamn krävs",
+    "telephoneNumberRequired": "Telefonnummer krävs",
+    "gdprLabel": "Jag har läst och godkänner",
+    "privacyPolicy": "sekretesspolicyn.",
+    "gdprRequired": "Du måste godkänna sekretesspolicyn för att registrera dig."
+  },
+  "car-booking": {
+    "title": "Bilbokning",
+    "description-title": "FAQ och regler",
+    "description": "Som medlem kan du boka sektionens bil för personliga och sektionrelaterade behov. Om du är administratör kan du hantera bokningar <0>här</0> istället. Genom att boka bilen godkänner du att följa reglerna som finns <1>här</1>.",
+    "faq": {
+      "title": "Vanliga frågor",
+      "q1": "Vem kan boka bilen?",
+      "a1": "Alla medlemmar i sektionen kan boka bilen.",
+      "q2": "Biluthyrning under sommaren?",
+      "a2": "Eftersom verksamheten är pausad under sommaren är det inte lätt att hyra sektionsbilen. Kontakta styrelsen på board (at) fsektionen.se för att höra om det går att lösa.",
+      "q3": "Hur många får plats i bilen?",
+      "a3": "Bilen har plats för upp till 7 personer, inklusive föraren.",
+      "q4": "Hur stort är lastutrymmet i bilen?",
+      "a4": "Bagageutrymmet (med nedfällda baksäten) är cirka (med reservation för att det inte är en perfekt rektangel) 190 cm djupt, 130 cm brett och 80 cm högt.",
+      "q5": "Vad kostar det att hyra bilen?",
+      "a5": "Medlemmar i F-sektionen betalar en startavgift på 150 kr. Startavgiften inkluderar 20 kilometer, därefter kostar det 5 kr per påbörjad kilometer.",
+      "q6": "Vad betyder färgerna?",
+      "a6": "Olika färger visar status och ägarskap för varje bokning. En administratör (bilförmannen) måste bekräfta bokningar utanför ordinarie tider. Färgerna har följande mening: \n- Ljusorange färg innebär att det är din bokning, men den är inte bekräftad.\n- Mörkorange färg innebär att det är din bokning och den är bekräftad. \n- Grön färg markerar någon annans bekräftade bokning.\n- Gul färg visar någon annans obekräftade bokning.\n- Ljusblå färg används för bokningar som lagts till lokalt men inte hämtats från servern än. Ser du blått kan något ha gått fel, ladda då om sidan.",
+      "q7": "Jag har fler frågor!",
+      "a7": "Du kan kontakta bilförmannen bland annat genom <0>kontaktsidan</0>. Be gärna bilförmannen eller spindelmännen att lägga till frågan med svar här."
+    }
+  },
+  "room-booking": {
+    "title": "Lokalbokning",
+    "description-title": "FAQ och regler",
+    "description": "Som medlem måste du kontakta en administratör om du vill boka ett rum, men du kan se alla rumsbokningar här. Om du är administratör kan du boka rum <0>här</0> istället.",
+    "faq": {
+      "title": "Vanliga frågor",
+      "q1": "Vem kan boka lokalerna?",
+      "a1": "Endast administratörer kan boka lokalerna. Om du är medlem kan du kontakta en person från nämnden eller ditt utskottsordförande för att be dem boka ett rum.",
+      "q2": "Jag har fler frågor!",
+      "a2": "Det finns ingen huvudansvarig för lokalbokning, kontakta prylmästaren eller styrelsen om du undrar något. Du kan också be dem att lägga till frågan med svar här."
+    }
+  },
+  "loading": {
+    "basic": "Laddar innehåll...",
+    "flavor_1": "Checkar in på Hilberts hotel...",
+    "flavor_2": "Hittar determinanten...",
+    "flavor_3": "Spelar moose game...",
+    "flavor_4": "Räknar ut sista siffran i π...",
+    "flavor_5": "Jäser mer Hilbeaux...",
+    "flavor_6": "Polerar pixlar...",
+    "flavor_7": "Räknar till oändligheten...",
+    "flavor_8": "Skapar ännu en gandalftenta...",
+    "flavor_9": "Bevisar Riemannhypotesen...",
+    "flavor_10": "Byter koordinatsystem...",
+    "flavor_11": "Preppar Hilbertmackor...",
+    "flavor_12": "Väntar på Ladokavisering...",
+    "flavor_13": "Väntar tills impulssvaret dör ut...",
+    "flavor_14": "Skriver motionssvar...",
+    "flavor_15": "Kompilerar LaTeX...",
+    "flavor_16": "Homogeniserar randvillkor...",
+    "error_occurred": "Ett fel uppstod:",
+    "no_error_message": "Inget felmeddelande tillgängligt.",
+    "network_error": "Ett nätverksfel uppstod. Kontrollera din anslutning.",
+    "unauthorized": "Du är inte auktoriserad att se detta innehåll. Logga in."
+  },
+  "cookieConsent": {
+    "message": "Vi använder cookies för att förbättra din upplevelse på vår webbplats (autentisering, språk och mer). Genom att fortsätta använda webbplatsen godkänner du vår användning av cookies.",
+    "accept": "Okej"
+  },
+  "permission-wall": {
+    "stop": "Stopp",
+    "subtitle": "Sakta i backarna!",
+    "message": "Du har inte behörighet att se denna sida. Om du tror att något är fel, ",
+    "contact": "kontakta din lokala spindelman",
+    "quote": "Här har vi begått lite småillegala saker längs vägen.",
+    "quote_author": "Mikael \"Micke P\" Persson Sundqvist",
+    "button": "Tillbaka till hemsidan"
+  },
+  "documents": {
+    "title": "Titel",
+    "created_at": "Skapad",
+    "private_explanation": "Endast medlemmar",
+    "author": "Författare",
+    "category": "Kategori",
+    "view": "Visa",
+    "view_doc": "Visa dokumentet",
+    "page_title": "Dokument",
+    "description": "Här kan du hitta och läsa dokument som delas inom sektionen. Vissa dokument är markerade för att endast vara synliga för medlemmar.",
+    "search_title": "Sök efter titel eller kategori",
+    "file_name": "Filnamn",
+    "updated_at": "Uppdaterad",
+    "is_private": "Visas endast för medlemmar"
+  },
+  "guild_meeting": {
+    "important_dates": "Viktiga datum"
+  },
+  "yes": "Ja",
+  "no": "Nej",
+  "not_found": "Hittades inte",
+  "description": "Beskrivning",
+  "event_signup": {
+    "title": "Eventanmälan",
+    "priority": "Prioritet",
+    "select_priority": "Välj prioritetsgrupp att anmäla dig med",
+    "group_name": "Gruppnamn",
+    "group_name_placeholder": "Ange gruppnamn (valfritt)",
+    "drink_package": {
+      "title": "Dryckespaket",
+      "none": "Inget",
+      "alcohol_free": "Alkoholfritt",
+      "alcohol": "Alkohol"
+    },
+    "select_drink_package": "Välj dryckespaket",
+    "button": "Anmäl dig",
+    "update_button": "Uppdatera anmälan",
+    "edit_button": "Redigera",
+    "signoff_button": "Avanmäl",
+    "success_create": "Anmälan lyckades!",
+    "success_update": "Anmälan uppdaterad!",
+    "success_signoff": "Du har avanmält dig från eventet.",
+    "error_create": "Kunde inte anmäla dig: {{error}}",
+    "error_update": "Kunde inte uppdatera anmälan: {{error}}",
+    "error_signoff": "Kunde inte avanmäla dig: {{error}}",
+    "unknown_error": "Okänt fel.",
+    "not_found": "Du är inte anmäld till detta event.",
+    "user": "Användare",
+    "status": "Status",
+    "confirmed": "Bekräftad",
+    "pending": "Väntar på bekräftelse",
+    "period_passed_signed_up": "Anmälningsperioden är slut. Om du vill ändra eller dra tillbaka din anmälan, kontakta eventansvarig.",
+    "period_passed_not_signed_up": "Anmälningsperioden är slut. Du kan inte längre anmäla dig. Om du har några frågor, vänligen kontakta eventansvarig.",
+    "food_preferences_title": "Matpreferenser",
+    "food_preferences_explainer": "Detta är dina sparade matpreferenser. Om något inte ser rätt ut kan du uppdatera dem i dina kontoinställningar.",
+    "standard_food_preferences": "Standardpreferenser:",
+    "other_food_preferences": "Övriga preferenser:",
+    "none": "Inga",
+    "signup_not_used": "Du kan inte anmäla dig till detta evenemang eftersom eventet inte använder systemet med anmälan för att delta."
+  },
+  "songs": {
+    "by": "Av",
+    "melody": "Melodi",
+    "category": "Kategori",
+    "views": "Visningar",
+    "title": "Sånger",
+    "description_subtitle": "Bläddra och sjung med i vår samling av sånger.",
+    "search_placeholder": "Sök sånger..."
+  },
+  "gallery": {
+    "title": "Galleri",
+    "select_year": "Välj år",
+    "photographers": "Fotografer"
+  },
+  "post": "Post",
+  "elections": {
+    "ended": "Avslutad",
+    "left": "kvar",
+    "day": "{{count}} dag(ar)",
+    "hour": "{{count}} h",
+    "min": "{{count}} min",
+    "no_visible_election": "Inget synligt val tillgängligt",
+    "post_name": "Postnamn",
+    "recommended_limit": "Rekommenderad gräns",
+    "max_limit": "Max gräns",
+    "candidation_count": "Kandidater",
+    "elected_by": "Vald av",
+    "council": "Utskott",
+    "end_time": "Sluttid",
+    "search_posts_placeholder": "Sök poster...",
+    "no_posts_match": "Inga poster matchar din sökning",
+    "view_my_candidations": "Visa mina kandidaturer",
+    "add_candidation": "Lägg till kandidatur",
+    "add_nomination": "Lägg till nominering",
+    "select_post": "Välj post",
+    "candidation_error": "Misslyckades att skapa kandidatur",
+    "candidation_success": "Kandidatur skapades!",
+    "nomination_error": "Misslyckades att skicka nominering",
+    "nomination_success": "Nominering skickad!",
+    "nominee_name": "Nominerade personens namn",
+    "nominee_email": "Nominerade personens e-post",
+    "motivation": "Motivering",
+    "election_limits": "Valgränser",
+    "ends_in": "Slutar om",
+    "actions": "Åtgärder",
+    "candidated_status": "Kandidaturstatus",
+    "you_have_candidated": "Du har kandiderat för denna post",
+    "candidated_at": "Kandiderade",
+    "remove_candidation": "Ta bort kandidatur",
+    "elected_at_semester": "Vald under termin",
+    "no_description": "Ingen beskrivning tillgänglig",
+    "my_candidations": {
+      "page_title": "Mina kandidaturer",
+      "page_description": "Här kan du se och hantera dina valkandidaturer"
+    },
+    "back_to_elections": "Tillbaka till val",
+    "no_candidations": "Du har inga kandidaturer",
+    "delete_candidation_success": "Kandidatur borttagen framgångsrikt",
+    "error_delete_candidation": "Misslyckades att ta bort kandidatur",
+    "limits": "Gränser",
+    "no_limit": "Ingen gräns",
+    "no_end_time": "Ingen sluttid",
+    "election_table_description": "Här är en lista över alla poster som är öppna för nomineringar och kandidaturer. Gränserna för hur många som kan bli valda till varje post är ordnade enligt rekommenderad gräns först, följt av maxgränsen.",
+    "sub_election": "Valkategori"
+  },
+  "info_box": {
+    "title": "Detaljer"
+  }
 }

--- a/src/locales/sv/main.json
+++ b/src/locales/sv/main.json
@@ -1,502 +1,502 @@
 {
-  "fsek": "F-sektionen",
-  "title": "Huvudsida",
-  "calendar": "Kalender",
-  "calendarText": "Här kan du se sektionens kalender med kommande evenemang. Klicka för att gå till stora kalendersidan och scrolla sedan ner för information om hur du lägger till detta i din egen kalenderapp.",
-  "welcome": "Välkommen till nya hemsidan för F-sektionen!",
-  "welcomeText": "Just nu är vi i en övergångsperiod till vår nya hemsida. Vi jobbar med att kontinuerligt förbättra design och funktionalitet, och lägga till saker som just nu saknas gentemot den gamla hemsidan. Den går fortfarande att använda på old.fsektionen.se. Eftersom vi dessutom har bytt ut servern och databasen är det nya och gamla systemet separerade: om du har gamla konton, lokalbokningar, inställningar, bilbokningar etc. så kommer de inte vara tillgängliga genom den nya webben och du kommer att behöva göra nya. OBS! Vi planerar att göra oss av med den gamla hemsidan helt inom en snar framtid, så försök att i största mån att använda den nya. Om du har några frågor eller synpunkter, tveka inte att kontakta spindel via spindelman@fsektionen.se.",
-  "oldWebsiteButton": "Det var bättre förr...",
-  "welcomeAdmin": "Om du anser att du borde ha någon form av administratörsåtkomst, försök klicka på knappen nedan, i navigeringsfältet eller gå till fsektionen.se/admin. Om du fortfarande inte har åtkomst, kontakta utskottsordförande.",
-  "adminButton": "Administrationssidan",
-  "registerButton": "Registrera nytt konto",
-  "newsTitle": "Nyheter",
-  "newsText": "Om du vill använda mer avancerad formattering, använd Mattermost som nyhetskanal tills vi har lagt till mer funktionalitet. Nyhetssidan stöder nu bilder!",
-  "cafeTitle": "Hilbert Café",
-  "cafeText": "Hilbert Café är en plats för studenter att träffas, studera och umgås. Här kommer du till slut hitta mer interaktiv information om caféet, dess öppettider och engagemang. Caféet har även en egen sida att tillgå, och du kan nu skriva upp dig på caféets arbetspass på en annan sida.",
-  "cafe_shift_button": "Skriv upp dig på ett arbetspass",
-  "cafe_page_button": "Huvudsidan för caféet",
-  "coolThing": "En häftig sak som distraherar dig från att se att sidan inte är klar än",
-  "back": "Tillbaka",
-  "faq": {
-    "self": "Frågor besvarade",
-    "q1": {
-      "question": "Kan jag logga in med mitt gamla konto?",
-      "answer": "Nej, eftersom vi bytt till en ny databas måste du skapa ett nytt konto, vilket du kan göra på fsektionen.se/register. Det finns många saker du inte har tillgång till innan du skapat ett konto, verifierat din mail och blivit verifierad som medlem."
-    },
-    "q2": {
-      "question": "Hur blir jag verifierad som medlem?",
-      "answer": "Skapa ett konto, verifiera din mejl och lägg till ditt Stil-ID (hi6122al-s) i användarinställningarna (kolla i övre högra hörnet). Efter detta måste du vänta på att vi ska se om du verkligen har medlemskap. I samband med terminsstart kan det ta längre tid än normalt. Om du känner att det tar för lång tid kan du kontakta din utskottsordförande, eller en fadder/föset under nollningen."
-    },
-    "q3": {
-      "question": "Vad har ni kvar att flytta över?",
-      "answer": "Det mesta finns redan överflyttat. För att läsa styrdokumenten i samlad form (de finns tillgängliga genom dokumentarkivet om du vet deras namn) eller använda motionsmaskinen kan du använda gamla hemsidan. Vi jobbar så hårt vi kan för att allt ska finnas på nya hemsidan 🧡."
-    },
-    "q4": {
-      "question": "Hjälp! Jag har inga av mina gamla adminrättigheter!",
-      "answer": "Vänta eller kontakta ditt utskottsordförande och be dem att återställa dina rättigheter."
-    },
-    "q5": {
-      "question": "Jag har problem med att anmäla mig till evenemang, visa galleriet eller andra saker!??",
-      "answer": "Vi hindrar icke-medlemmar och användare utan verifierade mailadresser från att använda många av våra tjänster. Kontrollera följande: \n\nAtt du verkligen har verifierat ditt konto (prova fsektionen.se/verify). \nAtt du är registrerad som medlem. (kolla i kontoinställningar för att kontrollera båda dessa!) \nAtt du är inloggad på rätt konto och inte har skapat flera konton, till exempel ett med din studentmail och ett annat med din privata mail. Om du har mer än ett konto och vill bli av med det dåliga, kontakta spindelman@fsektionen.se via mailet för det konto du vill ta bort."
-    }
-  },
-  "next": "Nästa",
-  "previous": "Föregående",
-  "page": "Sida",
-  "navbar": {
-    "sektionen": {
-      "self": "Sektionen",
-      "about": {
-        "self": "Om oss",
-        "desc": "Välkommen till vår sektion - lär känna oss och våra värderingar.",
-        "href": "/about"
-      },
-      "news": {
-        "self": "Nyheter",
-        "desc": "Håll dig uppdaterad med de senaste nyheterna från sektionen.",
-        "href": "/news"
-      },
-      "calendar": {
-        "self": "Kalender",
-        "desc": "Håll koll på kommande evenemang och aktiviteter.",
-        "href": "/calendar"
-      },
-      "councils": {
-        "self": "Utskott",
-        "desc": "Utforska våra utskotts arbete och engagemang.",
-        "href": "/councils"
-      },
-      "documents": {
-        "self": "Dokument",
-        "desc": "Bläddra bland dokument som producerats av sektionen.",
-        "href": "/documents"
-      },
-      "privacy": {
-        "self": "Sekretesspolicy",
-        "desc": "Läs mer om hur vi hanterar dina personuppgifter.",
-        "href": "/privacy"
-      },
-      "nollning": {
-        "self": "Nollning",
-        "desc": "Varmt välkommen till F-sektionen och grattis till din plats på civilingenjörsprogrammet i teknisk fysik, teknisk matematik eller teknisk nanovetenskap!",
-        "href": "/nollning"
-      }
-    },
-    "engage": {
-      "self": "Engagera dig",
-      "cafe": {
-        "self": "Hilbert Café",
-        "desc": "Träffa likasinnade och njut av en avslappnad atmosfär (och gratis lunch!).",
-        "href": "/cafe"
-      },
-      "positions": {
-        "self": "Bli funktionär",
-        "desc": "Vill du engagera dig i något utskott? Se hit!",
-        "href": "/positions"
-      },
-      "nollningsvol": {
-        "self": "Nollningsvolontärer",
-        "desc": "Hjälp oss att välkomna nya studenter och ge dem en bra start på studierna!",
-        "href": "/nollningsvolontar"
-      },
-      "elections": {
-        "self": "Val",
-        "desc": "Sök till sektionens poster!",
-        "href": "/election"
-      },
-      "projects": {
-        "self": "Projekt",
-        "desc": "Upptäck spännande initiativ och samarbeten inom sektionen.",
-        "href": "/projects"
-      },
-      "freja": {
-        "self": "FREJA",
-        "desc": "FREJA är en fristående organisation för dig som är kvinna eller icke-binär.",
-        "href": "https://www.frejalth.se/"
-      }
-    },
-    "services": {
-      "self": "Tjänster",
-      "car": {
-        "self": "Bilbokning",
-        "desc": "Boka bilen enkelt och smidigt för dina resor och behov.",
-        "href": "/car"
-      },
-      "rooms": {
-        "self": "Lokalbokning",
-        "desc": "Boka sektionens tre rum i Matematikhuset för personliga evenemang eller utskottsmöten.",
-        "href": "/room-bookings"
-      },
-      "tools": {
-        "self": "Verktygsutlåning",
-        "desc": "Låna sektionens verktyg för dina projekt.",
-        "href": "/tools"
-      },
-      "specialrooms": {
-        "self": "Stillarum/Bönerum",
-        "desc": "Hitta en lugn plats för reflektion eller bön.",
-        "href": "/stillarum"
-      },
-      "gallery": {
-        "self": "Galleri",
-        "desc": "Utforska vårt bildgalleri och få en inblick i sektionens historia.",
-        "href": "/gallery"
-      },
-      "calendar": {
-        "self": "Kalender",
-        "desc": "Håll koll på kommande evenemang och aktiviteter.",
-        "href": "/calendar"
-      },
-      "songs": {
-        "self": "Sångbok",
-        "desc": "Bläddra bland sångerna som sjungs på sektionens evenemang.",
-        "href": "/songs"
-      }
-    },
-    "companies": {
-      "self": "Företag",
-      "aboutCompany": {
-        "self": "Om F-sektionen",
-        "desc": "Upptäck vilka vi är och de program vi representerar.",
-        "href": "/foretag/om"
-      },
-      "offerings": {
-        "self": "Våra erbjudanden",
-        "desc": "Utforska förslag på samarbeten för att nå ut till våra medlemmar.",
-        "href": "/foretag/vi-erbjuder"
-      },
-      "farad": {
-        "self": "Farad",
-        "desc": "Läs mer om F-sektionens arbetsmarknadsmässa.",
-        "href": "https://farad.nu"
-      },
-      "contact": {
-        "self": "Företagskontakt",
-        "desc": "Kontakta oss för affärsförfrågningar och samarbeten.",
-        "href": "/contact#naringslivsutskottet"
-      }
-    },
-    "contact": {
-      "self": "Kontakt",
-      "contactPage": {
-        "self": "Kontaktsida",
-        "desc": "Här hittar du all information du behöver för att nå oss.",
-        "href": "/contact"
-      },
-      "ordf": {
-        "self": "Ordförande",
-        "desc": "För frågor om organisationen.",
-        "href": "/contact#ordf"
-      },
-      "web": {
-        "self": "Webbansvarig",
-        "desc": "För frågor om vår webbplats eller app.",
-        "href": "/contact#webmaster"
-      },
-      "anonymousForm": {
-        "self": "Anonymt kontaktformulär",
-        "desc": "För hemlig feedback eller bekymmer.",
-        "href": "https://docs.google.com/forms/d/e/1FAIpQLSdZdPl14DkdlZCKS3jzO59-FvVi2ug9nYer1jhYgERanbwHoQ/viewform"
-      },
-      "klaga": {
-        "self": "Klagomål",
-        "desc": "Skicka ett anonymt klagomål, en åsikt eller ändringsförslag till TLTH.",
-        "href": "https://www.tlth.se/klaga"
-      }
-    },
-    "booking": "Bokningar",
-    "documents": "Dokument",
-    "account-settings": "Kontoinställningar",
-    "logout": "Logga ut",
-    "logoutError": "Utloggning misslyckades. Försök igen senare.",
-    "verify": "Verifiera e-post",
-    "guild-meeting": "Sektionsmöte"
-  },
-  "footer": {
-    "contact": "Kontakt",
-    "emergencycontact": "Nödkontakt",
-    "companies": "För företag",
-    "webansvar": "Webbansvarig",
-    "ansvar": "Ansvarig utgivare",
-    "copyright": "F-sektionen. Alla rättigheter förvarade i superposition i ogenomtränglig låda."
-  },
-  "login": {
-    "login": "Logga in",
-    "invalid-email-or-password": "Fel e-postadress eller lösenord",
-    "email": "E-postadress",
-    "password": "Lösenord",
-    "title": "Logga in",
-    "registerPrompt": "Har du inget konto? Registrera dig här.",
-    "forgotPassword": "Glömt lösenord?",
-    "forgotEmailLabel": "Ange din e-post för att återställa lösenord",
-    "forgotSubmit": "Skicka återställningslänk",
-    "forgotLoading": "Skickar...",
-    "forgotSuccess": "Om din e-post finns så har en återställningslänk skickats till den.",
-    "backToLogin": "Tillbaka till inloggning",
-    "invalidEmailFormat": "Ogiltigt e-postformat"
-  },
-  "news": {
-    "self": "Nyheter",
-    "by": "Skriven av: ",
-    "pinned": "Fastnålad",
-    "see_all": "Se alla nyheter",
-    "read_more": "Läs mer"
-  },
-  "verifyMail": {
-    "loading": "Verifierar din e-post...",
-    "success": "E-postverifiering lyckades!",
-    "error": "E-postverifiering misslyckades. Länken kan ha gått ut eller varit ogiltig, eller så har du redan verifierat din e-post. Du kan gå till fsektionen.se/verify utan token för att få en ny länk.",
-    "goHome": "Gå till startsidan",
-    "noToken": "Du kan begära en ny verifieringslänk genom att ange din e-post nedan. (om du kom hit från ett mejl, kontrollera att du kopierade hela länken.)",
-    "requestSuccess": "En verifieringslänk har skickats till din e-postadress om den finns registrerad.",
-    "requestError": "Det gick inte att skicka verifieringsmejlet. Försök igen senare.",
-    "emailPlaceholder": "Ange din e-post",
-    "requestNew": "Begär ny verifieringslänk"
-  },
-  "verifyReminder": {
-    "message": "Ditt konto har inte en verifierad e-post. Du MÅSTE verifiera din e-post innan hemsidan kommer att fungera korrekt.",
-    "go": "Verifiera nu"
-  },
-  "memberBanner": {
-    "message": "Ditt konto är inte registrerat som medlem i F-sektionen. Du kan inte göra något åt detta själv. Kontakta din utskottsordförande eller annan ansvarig person inom sektionen för att bli registrerad som medlem. Innan detta kommer du inte kunna använda många av sektionens tjänster."
-  },
-  "reset-password": {
-    "title": "Återställ lösenord",
-    "password": "Nytt lösenord",
-    "retype-password": "Upprepa lösenord",
-    "passwords-do-not-match": "Lösenorden är olika",
-    "reset-password": "Återställ lösenord",
-    "resetting": "Återställer ditt lösenord...",
-    "reset-success": "Ditt lösenord har återställts!",
-    "goHome": "Gå till startsidan",
-    "reset-error": "Återställning av lösenord misslyckades.",
-    "invalid-reset-token": "Ogiltig eller saknad återställningslänk."
-  },
-  "register": {
-    "title": "Registrera ett konto",
-    "email": "E-postadress",
-    "password": "Lösenord",
-    "confirmPassword": "Bekräfta lösenord",
-    "firstName": "Förnamn",
-    "lastName": "Efternamn",
-    "telephone": "Telefonnummer med landskod (+46)",
-    "startYear": "Startår (valfritt)",
-    "submit": "Registrera",
-    "loginPrompt": "Har du redan ett konto? Logga in här.",
-    "loading": "Registrerar...",
-    "error": "Registreringen misslyckades. Kontrollera dina uppgifter och försök igen.",
-    "verifyError": "Användaren registrerades, men det gick inte att skicka verifieringsmail. Försök igen senare.",
-    "success": "Registreringen lyckades! Kontrollera din e-post för att verifiera ditt konto.",
-    "goLogin": "Gå till inloggning",
-    "passwordMismatch": "Lösenorden matchar inte. Försök igen.",
-    "passwordNoNumber": "Lösenordet måste innehålla minst ett nummer.",
-    "passwordNoLetter": "Lösenordet måste innehålla minst en bokstav (som inte är åäö).",
-    "startYearInvalid": "Startåret måste vara mellan 1960 och nuvarande år.",
-    "emailInvalid": "Ogiltig e-postadress",
-    "passwordShort": "Lösenordet måste vara minst 8 tecken",
-    "firstNameRequired": "Förnamn krävs",
-    "lastNameRequired": "Efternamn krävs",
-    "telephoneNumberRequired": "Telefonnummer krävs",
-    "gdprLabel": "Jag har läst och godkänner",
-    "privacyPolicy": "sekretesspolicyn.",
-    "gdprRequired": "Du måste godkänna sekretesspolicyn för att registrera dig."
-  },
-  "car-booking": {
-    "title": "Bilbokning",
-    "description-title": "FAQ och regler",
-    "description": "Som medlem kan du boka sektionens bil för personliga och sektionrelaterade behov. Om du är administratör kan du hantera bokningar <0>här</0> istället. Genom att boka bilen godkänner du att följa reglerna som finns <1>här</1>.",
-    "faq": {
-      "title": "Vanliga frågor",
-      "q1": "Vem kan boka bilen?",
-      "a1": "Alla medlemmar i sektionen kan boka bilen.",
-      "q2": "Biluthyrning under sommaren?",
-      "a2": "Eftersom verksamheten är pausad under sommaren är det inte lätt att hyra sektionsbilen. Kontakta styrelsen på board (at) fsektionen.se för att höra om det går att lösa.",
-      "q3": "Hur många får plats i bilen?",
-      "a3": "Bilen har plats för upp till 7 personer, inklusive föraren.",
-      "q4": "Hur stort är lastutrymmet i bilen?",
-      "a4": "Bagageutrymmet (med nedfällda baksäten) är cirka (med reservation för att det inte är en perfekt rektangel) 190 cm djupt, 130 cm brett och 80 cm högt.",
-      "q5": "Vad kostar det att hyra bilen?",
-      "a5": "Medlemmar i F-sektionen betalar en startavgift på 150 kr. Startavgiften inkluderar 20 kilometer, därefter kostar det 5 kr per påbörjad kilometer.",
-      "q6": "Vad betyder färgerna?",
-      "a6": "Olika färger visar status och ägarskap för varje bokning. En administratör (bilförmannen) måste bekräfta bokningar utanför ordinarie tider. Färgerna har följande mening: \n- Ljusorange färg innebär att det är din bokning, men den är inte bekräftad.\n- Mörkorange färg innebär att det är din bokning och den är bekräftad. \n- Grön färg markerar någon annans bekräftade bokning.\n- Gul färg visar någon annans obekräftade bokning.\n- Ljusblå färg används för bokningar som lagts till lokalt men inte hämtats från servern än. Ser du blått kan något ha gått fel, ladda då om sidan.",
-      "q7": "Jag har fler frågor!",
-      "a7": "Du kan kontakta bilförmannen bland annat genom <0>kontaktsidan</0>. Be gärna bilförmannen eller spindelmännen att lägga till frågan med svar här."
-    }
-  },
-  "room-booking": {
-    "title": "Lokalbokning",
-    "description-title": "FAQ och regler",
-    "description": "Som medlem måste du kontakta en administratör om du vill boka ett rum, men du kan se alla rumsbokningar här. Om du är administratör kan du boka rum <0>här</0> istället.",
-    "faq": {
-      "title": "Vanliga frågor",
-      "q1": "Vem kan boka lokalerna?",
-      "a1": "Endast administratörer kan boka lokalerna. Om du är medlem kan du kontakta en person från nämnden eller ditt utskottsordförande för att be dem boka ett rum.",
-      "q2": "Jag har fler frågor!",
-      "a2": "Det finns ingen huvudansvarig för lokalbokning, kontakta prylmästaren eller styrelsen om du undrar något. Du kan också be dem att lägga till frågan med svar här."
-    }
-  },
-  "loading": {
-    "basic": "Laddar innehåll...",
-    "flavor_1": "Checkar in på Hilberts hotel...",
-    "flavor_2": "Hittar determinanten...",
-    "flavor_3": "Spelar moose game...",
-    "flavor_4": "Räknar ut sista siffran i π...",
-    "flavor_5": "Jäser mer Hilbeaux...",
-    "flavor_6": "Polerar pixlar...",
-    "flavor_7": "Räknar till oändligheten...",
-    "flavor_8": "Skapar ännu en gandalftenta...",
-    "flavor_9": "Bevisar Riemannhypotesen...",
-    "flavor_10": "Byter koordinatsystem...",
-    "flavor_11": "Preppar Hilbertmackor...",
-    "flavor_12": "Väntar på Ladokavisering...",
-    "flavor_13": "Väntar tills impulssvaret dör ut...",
-    "flavor_14": "Skriver motionssvar...",
-    "flavor_15": "Kompilerar LaTeX...",
-    "flavor_16": "Homogeniserar randvillkor...",
-    "error_occurred": "Ett fel uppstod:",
-    "no_error_message": "Inget felmeddelande tillgängligt.",
-    "network_error": "Ett nätverksfel uppstod. Kontrollera din anslutning.",
-    "unauthorized": "Du är inte auktoriserad att se detta innehåll. Logga in."
-  },
-  "cookieConsent": {
-    "message": "Vi använder cookies för att förbättra din upplevelse på vår webbplats (autentisering, språk och mer). Genom att fortsätta använda webbplatsen godkänner du vår användning av cookies.",
-    "accept": "Okej"
-  },
-  "permission-wall": {
-    "stop": "Stopp",
-    "subtitle": "Sakta i backarna!",
-    "message": "Du har inte behörighet att se denna sida. Om du tror att något är fel, ",
-    "contact": "kontakta din lokala spindelman",
-    "quote": "Här har vi begått lite småillegala saker längs vägen.",
-    "quote_author": "Mikael \"Micke P\" Persson Sundqvist",
-    "button": "Tillbaka till hemsidan"
-  },
-  "documents": {
-    "title": "Titel",
-    "created_at": "Skapad",
-    "private_explanation": "Endast medlemmar",
-    "author": "Författare",
-    "category": "Kategori",
-    "view": "Visa",
-    "view_doc": "Visa dokumentet",
-    "page_title": "Dokument",
-    "description": "Här kan du hitta och läsa dokument som delas inom sektionen. Vissa dokument är markerade för att endast vara synliga för medlemmar.",
-    "search_title": "Sök efter titel eller kategori",
-    "file_name": "Filnamn",
-    "updated_at": "Uppdaterad",
-    "is_private": "Visas endast för medlemmar"
-  },
-  "guild_meeting": {
-    "important_dates": "Viktiga datum"
-  },
-  "yes": "Ja",
-  "no": "Nej",
-  "not_found": "Hittades inte",
-  "description": "Beskrivning",
-  "event_signup": {
-    "title": "Eventanmälan",
-    "priority": "Prioritet",
-    "select_priority": "Välj prioritetsgrupp att anmäla dig med",
-    "group_name": "Gruppnamn",
-    "group_name_placeholder": "Ange gruppnamn (valfritt)",
-    "drink_package": {
-      "title": "Dryckespaket",
-      "none": "Inget",
-      "alcohol_free": "Alkoholfritt",
-      "alcohol": "Alkohol"
-    },
-    "select_drink_package": "Välj dryckespaket",
-    "button": "Anmäl dig",
-    "update_button": "Uppdatera anmälan",
-    "edit_button": "Redigera",
-    "signoff_button": "Avanmäl",
-    "success_create": "Anmälan lyckades!",
-    "success_update": "Anmälan uppdaterad!",
-    "success_signoff": "Du har avanmält dig från eventet.",
-    "error_create": "Kunde inte anmäla dig: {{error}}",
-    "error_update": "Kunde inte uppdatera anmälan: {{error}}",
-    "error_signoff": "Kunde inte avanmäla dig: {{error}}",
-    "unknown_error": "Okänt fel.",
-    "not_found": "Du är inte anmäld till detta event.",
-    "user": "Användare",
-    "status": "Status",
-    "confirmed": "Bekräftad",
-    "pending": "Väntar på bekräftelse",
-    "period_passed_signed_up": "Anmälningsperioden är slut. Om du vill ändra eller dra tillbaka din anmälan, kontakta eventansvarig.",
-    "period_passed_not_signed_up": "Anmälningsperioden är slut. Du kan inte längre anmäla dig. Om du har några frågor, vänligen kontakta eventansvarig.",
-    "food_preferences_title": "Matpreferenser",
-    "food_preferences_explainer": "Detta är dina sparade matpreferenser. Om något inte ser rätt ut kan du uppdatera dem i dina kontoinställningar.",
-    "standard_food_preferences": "Standardpreferenser:",
-    "other_food_preferences": "Övriga preferenser:",
-    "none": "Inga",
-    "signup_not_used": "Du kan inte anmäla dig till detta evenemang eftersom eventet inte använder systemet med anmälan för att delta."
-  },
-  "songs": {
-    "by": "Av",
-    "melody": "Melodi",
-    "category": "Kategori",
-    "views": "Visningar",
-    "title": "Sånger",
-    "description_subtitle": "Bläddra och sjung med i vår samling av sånger.",
-    "search_placeholder": "Sök sånger..."
-  },
-  "gallery": {
-    "title": "Galleri",
-    "select_year": "Välj år",
-    "photographers": "Fotografer"
-  },
-  "post": "Post",
-  "elections": {
-    "ended": "Avslutad",
-    "left": "kvar",
-    "day": "{{count}} dag(ar)",
-    "hour": "{{count}} h",
-    "min": "{{count}} min",
-    "no_visible_election": "Inget synligt val tillgängligt",
-    "post_name": "Postnamn",
-    "recommended_limit": "Rekommenderad gräns",
-    "max_limit": "Max gräns",
-    "candidation_count": "Kandidater",
-    "elected_by": "Vald av",
-    "council": "Utskott",
-    "end_time": "Sluttid",
-    "search_posts_placeholder": "Sök poster...",
-    "no_posts_match": "Inga poster matchar din sökning",
-    "view_my_candidations": "Visa mina kandidaturer",
-    "add_candidation": "Lägg till kandidatur",
-    "add_nomination": "Lägg till nominering",
-    "select_post": "Välj post",
-    "candidation_error": "Misslyckades att skapa kandidatur",
-    "candidation_success": "Kandidatur skapades!",
-    "nomination_error": "Misslyckades att skicka nominering",
-    "nomination_success": "Nominering skickad!",
-    "nominee_name": "Nominerade personens namn",
-    "nominee_email": "Nominerade personens e-post",
-    "motivation": "Motivering",
-    "election_limits": "Valgränser",
-    "ends_in": "Slutar om",
-    "actions": "Åtgärder",
-    "candidated_status": "Kandidaturstatus",
-    "you_have_candidated": "Du har kandiderat för denna post",
-    "candidated_at": "Kandiderade",
-    "remove_candidation": "Ta bort kandidatur",
-    "elected_at_semester": "Vald under termin",
-    "no_description": "Ingen beskrivning tillgänglig",
-    "my_candidations": {
-      "page_title": "Mina kandidaturer",
-      "page_description": "Här kan du se och hantera dina valkandidaturer"
-    },
-    "back_to_elections": "Tillbaka till val",
-    "no_candidations": "Du har inga kandidaturer",
-    "delete_candidation_success": "Kandidatur borttagen framgångsrikt",
-    "error_delete_candidation": "Misslyckades att ta bort kandidatur",
-    "limits": "Gränser",
-    "no_limit": "Ingen gräns",
-    "no_end_time": "Ingen sluttid",
-    "election_table_description": "Här är en lista över alla poster som är öppna för nomineringar och kandidaturer. Gränserna för hur många som kan bli valda till varje post är ordnade enligt rekommenderad gräns först, följt av maxgränsen.",
-    "sub_election": "Valkategori"
-  },
-  "info_box": {
-    "title": "Detaljer"
-  }
+	"fsek": "F-sektionen",
+	"title": "Huvudsida",
+	"calendar": "Kalender",
+	"calendarText": "Här kan du se sektionens kalender med kommande evenemang. Klicka för att gå till stora kalendersidan och scrolla sedan ner för information om hur du lägger till detta i din egen kalenderapp.",
+	"welcome": "Välkommen till nya hemsidan för F-sektionen!",
+	"welcomeText": "Just nu är vi i en övergångsperiod till vår nya hemsida. Vi jobbar med att kontinuerligt förbättra design och funktionalitet, och lägga till saker som just nu saknas gentemot den gamla hemsidan. Den går fortfarande att använda på old.fsektionen.se. Eftersom vi dessutom har bytt ut servern och databasen är det nya och gamla systemet separerade: om du har gamla konton, lokalbokningar, inställningar, bilbokningar etc. så kommer de inte vara tillgängliga genom den nya webben och du kommer att behöva göra nya. OBS! Vi planerar att göra oss av med den gamla hemsidan helt inom en snar framtid, så försök att i största mån att använda den nya. Om du har några frågor eller synpunkter, tveka inte att kontakta spindel via spindelman@fsektionen.se.",
+	"oldWebsiteButton": "Det var bättre förr...",
+	"welcomeAdmin": "Om du anser att du borde ha någon form av administratörsåtkomst, försök klicka på knappen nedan, i navigeringsfältet eller gå till fsektionen.se/admin. Om du fortfarande inte har åtkomst, kontakta utskottsordförande.",
+	"adminButton": "Administrationssidan",
+	"registerButton": "Registrera nytt konto",
+	"newsTitle": "Nyheter",
+	"newsText": "Om du vill använda mer avancerad formattering, använd Mattermost som nyhetskanal tills vi har lagt till mer funktionalitet. Nyhetssidan stöder nu bilder!",
+	"cafeTitle": "Hilbert Café",
+	"cafeText": "Hilbert Café är en plats för studenter att träffas, studera och umgås. Här kommer du till slut hitta mer interaktiv information om caféet, dess öppettider och engagemang. Caféet har även en egen sida att tillgå, och du kan nu skriva upp dig på caféets arbetspass på en annan sida.",
+	"cafe_shift_button": "Skriv upp dig på ett arbetspass",
+	"cafe_page_button": "Huvudsidan för caféet",
+	"coolThing": "En häftig sak som distraherar dig från att se att sidan inte är klar än",
+	"back": "Tillbaka",
+	"faq": {
+		"self": "Frågor besvarade",
+		"q1": {
+			"question": "Kan jag logga in med mitt gamla konto?",
+			"answer": "Nej, eftersom vi bytt till en ny databas måste du skapa ett nytt konto, vilket du kan göra på fsektionen.se/register. Det finns många saker du inte har tillgång till innan du skapat ett konto, verifierat din mail och blivit verifierad som medlem."
+		},
+		"q2": {
+			"question": "Hur blir jag verifierad som medlem?",
+			"answer": "Skapa ett konto, verifiera din mejl och lägg till ditt Stil-ID (hi6122al-s) i användarinställningarna (kolla i övre högra hörnet). Efter detta måste du vänta på att vi ska se om du verkligen har medlemskap. I samband med terminsstart kan det ta längre tid än normalt. Om du känner att det tar för lång tid kan du kontakta din utskottsordförande, eller en fadder/föset under nollningen."
+		},
+		"q3": {
+			"question": "Vad har ni kvar att flytta över?",
+			"answer": "Det mesta finns redan överflyttat. För att läsa styrdokumenten i samlad form (de finns tillgängliga genom dokumentarkivet om du vet deras namn) eller använda motionsmaskinen kan du använda gamla hemsidan. Vi jobbar så hårt vi kan för att allt ska finnas på nya hemsidan 🧡."
+		},
+		"q4": {
+			"question": "Hjälp! Jag har inga av mina gamla adminrättigheter!",
+			"answer": "Vänta eller kontakta ditt utskottsordförande och be dem att återställa dina rättigheter."
+		},
+		"q5": {
+			"question": "Jag har problem med att anmäla mig till evenemang, visa galleriet eller andra saker!??",
+			"answer": "Vi hindrar icke-medlemmar och användare utan verifierade mailadresser från att använda många av våra tjänster. Kontrollera följande: \n\nAtt du verkligen har verifierat ditt konto (prova fsektionen.se/verify). \nAtt du är registrerad som medlem. (kolla i kontoinställningar för att kontrollera båda dessa!) \nAtt du är inloggad på rätt konto och inte har skapat flera konton, till exempel ett med din studentmail och ett annat med din privata mail. Om du har mer än ett konto och vill bli av med det dåliga, kontakta spindelman@fsektionen.se via mailet för det konto du vill ta bort."
+		}
+	},
+	"next": "Nästa",
+	"previous": "Föregående",
+	"page": "Sida",
+	"navbar": {
+		"sektionen": {
+			"self": "Sektionen",
+			"about": {
+				"self": "Om oss",
+				"desc": "Välkommen till vår sektion - lär känna oss och våra värderingar.",
+				"href": "/about"
+			},
+			"news": {
+				"self": "Nyheter",
+				"desc": "Håll dig uppdaterad med de senaste nyheterna från sektionen.",
+				"href": "/news"
+			},
+			"calendar": {
+				"self": "Kalender",
+				"desc": "Håll koll på kommande evenemang och aktiviteter.",
+				"href": "/calendar"
+			},
+			"councils": {
+				"self": "Utskott",
+				"desc": "Utforska våra utskotts arbete och engagemang.",
+				"href": "/councils"
+			},
+			"documents": {
+				"self": "Dokument",
+				"desc": "Bläddra bland dokument som producerats av sektionen.",
+				"href": "/documents"
+			},
+			"privacy": {
+				"self": "Sekretesspolicy",
+				"desc": "Läs mer om hur vi hanterar dina personuppgifter.",
+				"href": "/privacy"
+			},
+			"nollning": {
+				"self": "Nollning",
+				"desc": "Varmt välkommen till F-sektionen och grattis till din plats på civilingenjörsprogrammet i teknisk fysik, teknisk matematik eller teknisk nanovetenskap!",
+				"href": "/nollning"
+			}
+		},
+		"engage": {
+			"self": "Engagera dig",
+			"cafe": {
+				"self": "Hilbert Café",
+				"desc": "Träffa likasinnade och njut av en avslappnad atmosfär (och gratis lunch!).",
+				"href": "/cafe"
+			},
+			"positions": {
+				"self": "Bli funktionär",
+				"desc": "Vill du engagera dig i något utskott? Se hit!",
+				"href": "/positions"
+			},
+			"nollningsvol": {
+				"self": "Nollningsvolontärer",
+				"desc": "Hjälp oss att välkomna nya studenter och ge dem en bra start på studierna!",
+				"href": "/nollningsvolontar"
+			},
+			"elections": {
+				"self": "Val",
+				"desc": "Sök till sektionens poster!",
+				"href": "/election"
+			},
+			"projects": {
+				"self": "Projekt",
+				"desc": "Upptäck spännande initiativ och samarbeten inom sektionen.",
+				"href": "/projects"
+			},
+			"freja": {
+				"self": "FREJA",
+				"desc": "FREJA är en fristående organisation för dig som är kvinna eller icke-binär.",
+				"href": "https://www.frejalth.se/"
+			}
+		},
+		"services": {
+			"self": "Tjänster",
+			"car": {
+				"self": "Bilbokning",
+				"desc": "Boka bilen enkelt och smidigt för dina resor och behov.",
+				"href": "/car"
+			},
+			"rooms": {
+				"self": "Lokalbokning",
+				"desc": "Boka sektionens tre rum i Matematikhuset för personliga evenemang eller utskottsmöten.",
+				"href": "/room-bookings"
+			},
+			"tools": {
+				"self": "Verktygsutlåning",
+				"desc": "Låna sektionens verktyg för dina projekt.",
+				"href": "/tools"
+			},
+			"specialrooms": {
+				"self": "Stillarum/Bönerum",
+				"desc": "Hitta en lugn plats för reflektion eller bön.",
+				"href": "/stillarum"
+			},
+			"gallery": {
+				"self": "Galleri",
+				"desc": "Utforska vårt bildgalleri och få en inblick i sektionens historia.",
+				"href": "/gallery"
+			},
+			"calendar": {
+				"self": "Kalender",
+				"desc": "Håll koll på kommande evenemang och aktiviteter.",
+				"href": "/calendar"
+			},
+			"songs": {
+				"self": "Sångbok",
+				"desc": "Bläddra bland sångerna som sjungs på sektionens evenemang.",
+				"href": "/songs"
+			}
+		},
+		"companies": {
+			"self": "Företag",
+			"aboutCompany": {
+				"self": "Om F-sektionen",
+				"desc": "Upptäck vilka vi är och de program vi representerar.",
+				"href": "/foretag/om"
+			},
+			"offerings": {
+				"self": "Våra erbjudanden",
+				"desc": "Utforska förslag på samarbeten för att nå ut till våra medlemmar.",
+				"href": "/foretag/vi-erbjuder"
+			},
+			"farad": {
+				"self": "Farad",
+				"desc": "Läs mer om F-sektionens arbetsmarknadsmässa.",
+				"href": "https://farad.nu"
+			},
+			"contact": {
+				"self": "Företagskontakt",
+				"desc": "Kontakta oss för affärsförfrågningar och samarbeten.",
+				"href": "/contact#naringslivsutskottet"
+			}
+		},
+		"contact": {
+			"self": "Kontakt",
+			"contactPage": {
+				"self": "Kontaktsida",
+				"desc": "Här hittar du all information du behöver för att nå oss.",
+				"href": "/contact"
+			},
+			"ordf": {
+				"self": "Ordförande",
+				"desc": "För frågor om organisationen.",
+				"href": "/contact#ordf"
+			},
+			"web": {
+				"self": "Webbansvarig",
+				"desc": "För frågor om vår webbplats eller app.",
+				"href": "/contact#webmaster"
+			},
+			"anonymousForm": {
+				"self": "Anonymt kontaktformulär",
+				"desc": "För hemlig feedback eller bekymmer.",
+				"href": "https://docs.google.com/forms/d/e/1FAIpQLSdZdPl14DkdlZCKS3jzO59-FvVi2ug9nYer1jhYgERanbwHoQ/viewform"
+			},
+			"klaga": {
+				"self": "Klagomål",
+				"desc": "Skicka ett anonymt klagomål, en åsikt eller ändringsförslag till TLTH.",
+				"href": "https://www.tlth.se/klaga"
+			}
+		},
+		"booking": "Bokningar",
+		"documents": "Dokument",
+		"account-settings": "Kontoinställningar",
+		"logout": "Logga ut",
+		"logoutError": "Utloggning misslyckades. Försök igen senare.",
+		"verify": "Verifiera e-post",
+		"guild-meeting": "Sektionsmöte"
+	},
+	"footer": {
+		"contact": "Kontakt",
+		"emergencycontact": "Nödkontakt",
+		"companies": "För företag",
+		"webansvar": "Webbansvarig",
+		"ansvar": "Ansvarig utgivare",
+		"copyright": "F-sektionen. Alla rättigheter förvarade i superposition i ogenomtränglig låda."
+	},
+	"login": {
+		"login": "Logga in",
+		"invalid-email-or-password": "Fel e-postadress eller lösenord",
+		"email": "E-postadress",
+		"password": "Lösenord",
+		"title": "Logga in",
+		"registerPrompt": "Har du inget konto? Registrera dig här.",
+		"forgotPassword": "Glömt lösenord?",
+		"forgotEmailLabel": "Ange din e-post för att återställa lösenord",
+		"forgotSubmit": "Skicka återställningslänk",
+		"forgotLoading": "Skickar...",
+		"forgotSuccess": "Om din e-post finns så har en återställningslänk skickats till den.",
+		"backToLogin": "Tillbaka till inloggning",
+		"invalidEmailFormat": "Ogiltigt e-postformat"
+	},
+	"news": {
+		"self": "Nyheter",
+		"by": "Skriven av: ",
+		"pinned": "Fastnålad",
+		"see_all": "Se alla nyheter",
+		"read_more": "Läs mer"
+	},
+	"verifyMail": {
+		"loading": "Verifierar din e-post...",
+		"success": "E-postverifiering lyckades!",
+		"error": "E-postverifiering misslyckades. Länken kan ha gått ut eller varit ogiltig, eller så har du redan verifierat din e-post. Du kan gå till fsektionen.se/verify utan token för att få en ny länk.",
+		"goHome": "Gå till startsidan",
+		"noToken": "Du kan begära en ny verifieringslänk genom att ange din e-post nedan. (om du kom hit från ett mejl, kontrollera att du kopierade hela länken.)",
+		"requestSuccess": "En verifieringslänk har skickats till din e-postadress om den finns registrerad.",
+		"requestError": "Det gick inte att skicka verifieringsmejlet. Försök igen senare.",
+		"emailPlaceholder": "Ange din e-post",
+		"requestNew": "Begär ny verifieringslänk"
+	},
+	"verifyReminder": {
+		"message": "Ditt konto har inte en verifierad e-post. Du MÅSTE verifiera din e-post innan hemsidan kommer att fungera korrekt.",
+		"go": "Verifiera nu"
+	},
+	"memberBanner": {
+		"message": "Ditt konto är inte registrerat som medlem i F-sektionen. Du kan inte göra något åt detta själv. Kontakta din utskottsordförande eller annan ansvarig person inom sektionen för att bli registrerad som medlem. Innan detta kommer du inte kunna använda många av sektionens tjänster."
+	},
+	"reset-password": {
+		"title": "Återställ lösenord",
+		"password": "Nytt lösenord",
+		"retype-password": "Upprepa lösenord",
+		"passwords-do-not-match": "Lösenorden är olika",
+		"reset-password": "Återställ lösenord",
+		"resetting": "Återställer ditt lösenord...",
+		"reset-success": "Ditt lösenord har återställts!",
+		"goHome": "Gå till startsidan",
+		"reset-error": "Återställning av lösenord misslyckades.",
+		"invalid-reset-token": "Ogiltig eller saknad återställningslänk."
+	},
+	"register": {
+		"title": "Registrera ett konto",
+		"email": "E-postadress",
+		"password": "Lösenord",
+		"confirmPassword": "Bekräfta lösenord",
+		"firstName": "Förnamn",
+		"lastName": "Efternamn",
+		"telephone": "Telefonnummer med landskod (+46)",
+		"startYear": "Startår (valfritt)",
+		"submit": "Registrera",
+		"loginPrompt": "Har du redan ett konto? Logga in här.",
+		"loading": "Registrerar...",
+		"error": "Registreringen misslyckades. Kontrollera dina uppgifter och försök igen.",
+		"verifyError": "Användaren registrerades, men det gick inte att skicka verifieringsmail. Försök igen senare.",
+		"success": "Registreringen lyckades! Kontrollera din e-post för att verifiera ditt konto.",
+		"goLogin": "Gå till inloggning",
+		"passwordMismatch": "Lösenorden matchar inte. Försök igen.",
+		"passwordNoNumber": "Lösenordet måste innehålla minst ett nummer.",
+		"passwordNoLetter": "Lösenordet måste innehålla minst en bokstav (som inte är åäö).",
+		"startYearInvalid": "Startåret måste vara mellan 1960 och nuvarande år.",
+		"emailInvalid": "Ogiltig e-postadress",
+		"passwordShort": "Lösenordet måste vara minst 8 tecken",
+		"firstNameRequired": "Förnamn krävs",
+		"lastNameRequired": "Efternamn krävs",
+		"telephoneNumberRequired": "Telefonnummer krävs",
+		"gdprLabel": "Jag har läst och godkänner",
+		"privacyPolicy": "sekretesspolicyn.",
+		"gdprRequired": "Du måste godkänna sekretesspolicyn för att registrera dig."
+	},
+	"car-booking": {
+		"title": "Bilbokning",
+		"description-title": "FAQ och regler",
+		"description": "Som medlem kan du boka sektionens bil för personliga och sektionrelaterade behov. Om du är administratör kan du hantera bokningar <0>här</0> istället. Genom att boka bilen godkänner du att följa reglerna som finns <1>här</1>.",
+		"faq": {
+			"title": "Vanliga frågor",
+			"q1": "Vem kan boka bilen?",
+			"a1": "Alla medlemmar i sektionen kan boka bilen.",
+			"q2": "Biluthyrning under sommaren?",
+			"a2": "Eftersom verksamheten är pausad under sommaren är det inte lätt att hyra sektionsbilen. Kontakta styrelsen på board (at) fsektionen.se för att höra om det går att lösa.",
+			"q3": "Hur många får plats i bilen?",
+			"a3": "Bilen har plats för upp till 7 personer, inklusive föraren.",
+			"q4": "Hur stort är lastutrymmet i bilen?",
+			"a4": "Bagageutrymmet (med nedfällda baksäten) är cirka (med reservation för att det inte är en perfekt rektangel) 190 cm djupt, 130 cm brett och 80 cm högt.",
+			"q5": "Vad kostar det att hyra bilen?",
+			"a5": "Medlemmar i F-sektionen betalar en startavgift på 150 kr. Startavgiften inkluderar 20 kilometer, därefter kostar det 5 kr per påbörjad kilometer.",
+			"q6": "Vad betyder färgerna?",
+			"a6": "Olika färger visar status och ägarskap för varje bokning. En administratör (bilförmannen) måste bekräfta bokningar utanför ordinarie tider. Färgerna har följande mening: \n- Ljusorange färg innebär att det är din bokning, men den är inte bekräftad.\n- Mörkorange färg innebär att det är din bokning och den är bekräftad. \n- Grön färg markerar någon annans bekräftade bokning.\n- Gul färg visar någon annans obekräftade bokning.\n- Ljusblå färg används för bokningar som lagts till lokalt men inte hämtats från servern än. Ser du blått kan något ha gått fel, ladda då om sidan.",
+			"q7": "Jag har fler frågor!",
+			"a7": "Du kan kontakta bilförmannen bland annat genom <0>kontaktsidan</0>. Be gärna bilförmannen eller spindelmännen att lägga till frågan med svar här."
+		}
+	},
+	"room-booking": {
+		"title": "Lokalbokning",
+		"description-title": "FAQ och regler",
+		"description": "Som medlem måste du kontakta en administratör om du vill boka ett rum, men du kan se alla rumsbokningar här. Om du är administratör kan du boka rum <0>här</0> istället.",
+		"faq": {
+			"title": "Vanliga frågor",
+			"q1": "Vem kan boka lokalerna?",
+			"a1": "Endast administratörer kan boka lokalerna. Om du är medlem kan du kontakta en person från nämnden eller ditt utskottsordförande för att be dem boka ett rum.",
+			"q2": "Jag har fler frågor!",
+			"a2": "Det finns ingen huvudansvarig för lokalbokning, kontakta prylmästaren eller styrelsen om du undrar något. Du kan också be dem att lägga till frågan med svar här."
+		}
+	},
+	"loading": {
+		"basic": "Laddar innehåll...",
+		"flavor_1": "Checkar in på Hilberts hotel...",
+		"flavor_2": "Hittar determinanten...",
+		"flavor_3": "Spelar moose game...",
+		"flavor_4": "Räknar ut sista siffran i π...",
+		"flavor_5": "Jäser mer Hilbeaux...",
+		"flavor_6": "Polerar pixlar...",
+		"flavor_7": "Räknar till oändligheten...",
+		"flavor_8": "Skapar ännu en gandalftenta...",
+		"flavor_9": "Bevisar Riemannhypotesen...",
+		"flavor_10": "Byter koordinatsystem...",
+		"flavor_11": "Preppar Hilbertmackor...",
+		"flavor_12": "Väntar på Ladokavisering...",
+		"flavor_13": "Väntar tills impulssvaret dör ut...",
+		"flavor_14": "Skriver motionssvar...",
+		"flavor_15": "Kompilerar LaTeX...",
+		"flavor_16": "Homogeniserar randvillkor...",
+		"error_occurred": "Ett fel uppstod:",
+		"no_error_message": "Inget felmeddelande tillgängligt.",
+		"network_error": "Ett nätverksfel uppstod. Kontrollera din anslutning.",
+		"unauthorized": "Du är inte auktoriserad att se detta innehåll. Logga in."
+	},
+	"cookieConsent": {
+		"message": "Vi använder cookies för att förbättra din upplevelse på vår webbplats (autentisering, språk och mer). Genom att fortsätta använda webbplatsen godkänner du vår användning av cookies.",
+		"accept": "Okej"
+	},
+	"permission-wall": {
+		"stop": "Stopp",
+		"subtitle": "Sakta i backarna!",
+		"message": "Du har inte behörighet att se denna sida. Om du tror att något är fel, ",
+		"contact": "kontakta din lokala spindelman",
+		"quote": "Här har vi begått lite småillegala saker längs vägen.",
+		"quote_author": "Mikael \"Micke P\" Persson Sundqvist",
+		"button": "Tillbaka till hemsidan"
+	},
+	"documents": {
+		"title": "Titel",
+		"created_at": "Skapad",
+		"private_explanation": "Endast medlemmar",
+		"author": "Författare",
+		"category": "Kategori",
+		"view": "Visa",
+		"view_doc": "Visa dokumentet",
+		"page_title": "Dokument",
+		"description": "Här kan du hitta och läsa dokument som delas inom sektionen. Vissa dokument är markerade för att endast vara synliga för medlemmar.",
+		"search_title": "Sök efter titel eller kategori",
+		"file_name": "Filnamn",
+		"updated_at": "Uppdaterad",
+		"is_private": "Visas endast för medlemmar"
+	},
+	"guild_meeting": {
+		"important_dates": "Viktiga datum"
+	},
+	"yes": "Ja",
+	"no": "Nej",
+	"not_found": "Hittades inte",
+	"description": "Beskrivning",
+	"event_signup": {
+		"title": "Eventanmälan",
+		"priority": "Prioritet",
+		"select_priority": "Välj prioritetsgrupp att anmäla dig med",
+		"group_name": "Gruppnamn",
+		"group_name_placeholder": "Ange gruppnamn (valfritt)",
+		"drink_package": {
+			"title": "Dryckespaket",
+			"none": "Inget",
+			"alcohol_free": "Alkoholfritt",
+			"alcohol": "Alkohol"
+		},
+		"select_drink_package": "Välj dryckespaket",
+		"button": "Anmäl dig",
+		"update_button": "Uppdatera anmälan",
+		"edit_button": "Redigera",
+		"signoff_button": "Avanmäl",
+		"success_create": "Anmälan lyckades!",
+		"success_update": "Anmälan uppdaterad!",
+		"success_signoff": "Du har avanmält dig från eventet.",
+		"error_create": "Kunde inte anmäla dig: {{error}}",
+		"error_update": "Kunde inte uppdatera anmälan: {{error}}",
+		"error_signoff": "Kunde inte avanmäla dig: {{error}}",
+		"unknown_error": "Okänt fel.",
+		"not_found": "Du är inte anmäld till detta event.",
+		"user": "Användare",
+		"status": "Status",
+		"confirmed": "Bekräftad",
+		"pending": "Väntar på bekräftelse",
+		"period_passed_signed_up": "Anmälningsperioden är slut. Om du vill ändra eller dra tillbaka din anmälan, kontakta eventansvarig.",
+		"period_passed_not_signed_up": "Anmälningsperioden är slut. Du kan inte längre anmäla dig. Om du har några frågor, vänligen kontakta eventansvarig.",
+		"food_preferences_title": "Matpreferenser",
+		"food_preferences_explainer": "Detta är dina sparade matpreferenser. Om något inte ser rätt ut kan du uppdatera dem i dina kontoinställningar.",
+		"standard_food_preferences": "Standardpreferenser:",
+		"other_food_preferences": "Övriga preferenser:",
+		"none": "Inga",
+		"signup_not_used": "Du kan inte anmäla dig till detta evenemang eftersom eventet inte använder systemet med anmälan för att delta."
+	},
+	"songs": {
+		"by": "Av",
+		"melody": "Melodi",
+		"category": "Kategori",
+		"views": "Visningar",
+		"title": "Sånger",
+		"description_subtitle": "Bläddra och sjung med i vår samling av sånger.",
+		"search_placeholder": "Sök sånger..."
+	},
+	"gallery": {
+		"title": "Galleri",
+		"select_year": "Välj år",
+		"photographers": "Fotografer"
+	},
+	"post": "Post",
+	"elections": {
+		"ended": "Avslutad",
+		"left": "kvar",
+		"day": "{{count}} dag(ar)",
+		"hour": "{{count}} h",
+		"min": "{{count}} min",
+		"no_visible_election": "Inget synligt val tillgängligt",
+		"post_name": "Postnamn",
+		"recommended_limit": "Rekommenderad gräns",
+		"max_limit": "Max gräns",
+		"candidation_count": "Kandidater",
+		"elected_by": "Vald av",
+		"council": "Utskott",
+		"end_time": "Sluttid",
+		"search_posts_placeholder": "Sök poster...",
+		"no_posts_match": "Inga poster matchar din sökning",
+		"view_my_candidations": "Visa mina kandidaturer",
+		"add_candidation": "Lägg till kandidatur",
+		"add_nomination": "Lägg till nominering",
+		"select_post": "Välj post",
+		"candidation_error": "Misslyckades att skapa kandidatur",
+		"candidation_success": "Kandidatur skapades!",
+		"nomination_error": "Misslyckades att skicka nominering",
+		"nomination_success": "Nominering skickad!",
+		"nominee_name": "Nominerade personens namn",
+		"nominee_email": "Nominerade personens e-post",
+		"motivation": "Motivering",
+		"election_limits": "Valgränser",
+		"ends_in": "Slutar om",
+		"actions": "Åtgärder",
+		"candidated_status": "Kandidaturstatus",
+		"you_have_candidated": "Du har kandiderat för denna post",
+		"candidated_at": "Kandiderade",
+		"remove_candidation": "Ta bort kandidatur",
+		"elected_at_semester": "Vald under termin",
+		"no_description": "Ingen beskrivning tillgänglig",
+		"my_candidations": {
+			"page_title": "Mina kandidaturer",
+			"page_description": "Här kan du se och hantera dina valkandidaturer"
+		},
+		"back_to_elections": "Tillbaka till val",
+		"no_candidations": "Du har inga kandidaturer",
+		"delete_candidation_success": "Kandidatur borttagen framgångsrikt",
+		"error_delete_candidation": "Misslyckades att ta bort kandidatur",
+		"limits": "Gränser",
+		"no_limit": "Ingen gräns",
+		"no_end_time": "Ingen sluttid",
+		"election_table_description": "Här är en lista över alla poster som är öppna för nomineringar och kandidaturer. Gränserna för hur många som kan bli valda till varje post är ordnade enligt rekommenderad gräns först, följt av maxgränsen.",
+		"sub_election": "Valkategori"
+	},
+	"info_box": {
+		"title": "Detaljer"
+	}
 }

--- a/src/locales/sv/main.json
+++ b/src/locales/sv/main.json
@@ -369,7 +369,8 @@
 		"contact": "kontakta din lokala spindelman",
 		"quote": "Här har vi begått lite småillegala saker längs vägen.",
 		"quote_author": "Mikael \"Micke P\" Persson Sundqvist",
-		"button": "Tillbaka till hemsidan"
+		"button": "Tillbaka till hemsidan",
+		"error": "Misslyckades med att hämta dina behörigheter."
 	},
 	"documents": {
 		"title": "Titel",

--- a/src/locales/sv/main.json
+++ b/src/locales/sv/main.json
@@ -369,8 +369,7 @@
 		"contact": "kontakta din lokala spindelman",
 		"quote": "Här har vi begått lite småillegala saker längs vägen.",
 		"quote_author": "Mikael \"Micke P\" Persson Sundqvist",
-		"button": "Tillbaka till hemsidan",
-		"error": "Misslyckades med att hämta dina behörigheter."
+		"button": "Tillbaka till hemsidan"
 	},
 	"documents": {
 		"title": "Titel",


### PR DESCRIPTION
Fetches the current user's (or non-user's) permissions from the backend instead of using the JWT. The PR compiles without errors when the backend changes are used. Changes:

- Use the new (improved!) getMyPermissions router from the backend instead of the unconventional JWT permission hack
- New method for accessing permissions (usePermissions)
- Adding loading skeleton to admin sidebar
- Clear queryClient cache when logging out and in
- Tiny unrelated and inconsequential bugfixes

Since the PR changes how Permission wall picks up permissions, it needs to be pushed to prod right after the corresponding backend fixes:
- https://github.com/fsek/WebWebWeb/pull/525