### PR TITLE
fix: disallow changing keyval key in edit form

### DIFF
--- a/src/app/admin/keyvals/KeyvalEditForm.tsx
+++ b/src/app/admin/keyvals/KeyvalEditForm.tsx
@@ -121,6 +121,7 @@ export default function KeyvalEditForm({ onClose, item }: KeyvalEditFormProps) {
 					name: "key",
 					label: t("keyvals.key"),
 					placeholder: t("keyvals.key_placeholder"),
+					readOnly: true,
 				},
 				{
 					variant: "text",

--- a/src/widgets/AdminForm.tsx
+++ b/src/widgets/AdminForm.tsx
@@ -35,6 +35,7 @@ type BaseAdminFormInputField<T extends FieldValues> = {
 	name: Path<T>;
 	label: string;
 	colSpan?: number;
+	readOnly?: boolean;
 };
 
 type TextAdminFormInputField<T extends FieldValues> =
@@ -223,6 +224,7 @@ export default function AdminForm<T extends FieldValues>({
 																placeholder={inputField.placeholder}
 																{...field}
 																value={(field.value ?? "") as string}
+																readOnly={inputField.readOnly}
 															/>
 														</FormControl>
 														<FormMessage />


### PR DESCRIPTION
Closes #304

Makes the key field read-only in the keyval edit form so users cannot change the key — prevents the "not found" error that occurred when the form tried to update a non-existent keyval with a new key.