### PR TITLE
Changed info on Teknologkåren's membership fee on the nollning page.

### DIFF
--- a/src/app/(public)/(mdx)/nollning/page.en.mdx
+++ b/src/app/(public)/(mdx)/nollning/page.en.mdx
@@ -95,7 +95,7 @@ Engineering nanoscience: N1 and N1 intro
 
 ## Become a member of the Engineering Student Union
 
-To participate in the introduction at both the F-guild and Teknologkåren, you must be a member, and it is through the union that you will receive your student ID. The membership fee is SEK 500 and is valid for your entire period of study. You can become a member here: https://www.tlth.se/bli-medlem
+To participate in the introduction at both the F-guild and Teknologkåren, you must be a member, and it is through the union that you will receive your student ID. The membership fee is SEK 600 and is valid for your entire period of study. You can become a member here: https://www.tlth.se/bli-medlem
 
 
 

--- a/src/app/(public)/(mdx)/nollning/page.sv.mdx
+++ b/src/app/(public)/(mdx)/nollning/page.sv.mdx
@@ -97,7 +97,7 @@ Se till att klicka in på “Mottagningsvecka LTH”. För att hitta just ditt s
 
 
 ## Bli medlem i Teknologkåren
-För att kunna ta del av nollningen på både F-sektionen och Teknologkåren måste du vara medlem, och det är via kåren du får din studentlegitimation. Medlemsavgiften ligger på 500 kr och det gäller för hela din studietid. Du blir medlem på TLTH:s hemsida på https://www.tlth.se/bli-medlem. 
+För att kunna ta del av nollningen på både F-sektionen och Teknologkåren måste du vara medlem, och det är via kåren du får din studentlegitimation. Medlemsavgiften ligger på 600 kr och det gäller för hela din studietid. Du blir medlem på TLTH:s hemsida på https://www.tlth.se/bli-medlem. 
 
 
 


### PR DESCRIPTION
The fee has been updated to 600 SEK and the nollning page now shows the correct value.