### PR TITLE
Allow admins to set unlock codes and hints for adventure missions. 

### DIFF
--- a/src/app/admin/nollning/admin-nollning/adventure-missions/createAdventureMission.tsx
+++ b/src/app/admin/nollning/admin-nollning/adventure-missions/createAdventureMission.tsx
@@ -2,30 +2,14 @@ import {
 	createAdventureMissionMutation,
 	getNollningQueryKey,
 } from "@/api/@tanstack/react-query.gen";
-import { Button } from "@/components/ui/button";
-import {
-	DialogClose,
-	DialogContent,
-	DialogHeader,
-	DialogTitle,
-	DialogTrigger,
-} from "@/components/ui/dialog";
-import {
-	Form,
-	FormControl,
-	FormField,
-	FormItem,
-	FormLabel,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Dialog } from "@radix-ui/react-dialog";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
+import AdminForm from "@/widgets/AdminForm";
 
 const AdventureMissionSchema = z.object({
 	title_sv: z.string().min(2),
@@ -35,6 +19,9 @@ const AdventureMissionSchema = z.object({
 	max_points: z.number().min(1),
 	min_points: z.number().min(0),
 	nollning_week: z.number().min(0).max(4),
+	unlock_code: z.string().optional(),
+	unlock_hint_sv: z.string().optional(),
+	unlock_hint_en: z.string().optional(),
 });
 
 interface Props {
@@ -44,19 +31,6 @@ interface Props {
 const CreateAdventureMission = ({ nollningID }: Props) => {
 	const [open, setOpen] = useState(false);
 	const { t } = useTranslation("admin");
-
-	const adventureMissionForm = useForm<z.infer<typeof AdventureMissionSchema>>({
-		resolver: zodResolver(AdventureMissionSchema),
-		defaultValues: {
-			title_sv: "",
-			title_en: "",
-			description_sv: "",
-			description_en: "",
-			max_points: 1,
-			min_points: 0,
-			nollning_week: 0,
-		},
-	});
 
 	const queryClient = useQueryClient();
 
@@ -87,196 +61,100 @@ const CreateAdventureMission = ({ nollningID }: Props) => {
 				max_points: values.max_points,
 				min_points: values.min_points,
 				nollning_week: values.nollning_week,
+				unlock_code: values.unlock_code,
+				unlock_hint_sv: values.unlock_hint_sv,
+				unlock_hint_en: values.unlock_hint_en,
 			},
 			path: { nollning_id: nollningID },
 		});
 	}
 
 	return (
-		<div>
-			<Dialog open={open} onOpenChange={setOpen}>
-				<DialogTrigger asChild>
-					<Button
-						onClick={() => {
-							adventureMissionForm.reset();
-						}}
-					>
-						{t("nollning.missions.create_button")}
-					</Button>
-				</DialogTrigger>
-				<DialogContent className="min-w-fit lg:max-w-7xl max-h-[80vh] overflow-y-auto">
-					<DialogHeader>
-						<DialogTitle className="text-3xl py-3 font-bold text-primary">
-							{t("nollning.missions.create_title")}
-						</DialogTitle>
-					</DialogHeader>
-					<Form {...adventureMissionForm}>
-						<form
-							onSubmit={adventureMissionForm.handleSubmit(onSubmit)}
-							className="w-full"
-						>
-							<div className="px-8 space-x-4 grid grid-cols-1 md:grid-cols-2 gap-4 w-full">
-								<FormField
-									control={adventureMissionForm.control}
-									name={"title_sv"}
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>{t("nollning.missions.title_sv")}</FormLabel>
-											<FormControl>
-												<Input
-													placeholder={t("nollning.missions.title_placeholder")}
-													{...field}
-												/>
-											</FormControl>
-										</FormItem>
-									)}
-								/>
-								<FormField
-									control={adventureMissionForm.control}
-									name={"title_en"}
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>{t("nollning.missions.title_en")}</FormLabel>
-											<FormControl>
-												<Input
-													placeholder={t("nollning.missions.title_placeholder")}
-													{...field}
-												/>
-											</FormControl>
-										</FormItem>
-									)}
-								/>
-								<FormField
-									control={adventureMissionForm.control}
-									name={"description_sv"}
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>
-												{t("nollning.missions.description_sv")}
-											</FormLabel>
-											<FormControl>
-												<textarea
-													className="w-full min-h-[100px] rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-													placeholder={t(
-														"nollning.missions.description_placeholder",
-													)}
-													{...field}
-												/>
-											</FormControl>
-										</FormItem>
-									)}
-								/>
-								<FormField
-									control={adventureMissionForm.control}
-									name={"description_en"}
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>
-												{t("nollning.missions.description_en")}
-											</FormLabel>
-											<FormControl>
-												<textarea
-													className="w-full min-h-[100px] rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-													placeholder={t(
-														"nollning.missions.description_placeholder",
-													)}
-													{...field}
-												/>
-											</FormControl>
-										</FormItem>
-									)}
-								/>
-								<FormField
-									control={adventureMissionForm.control}
-									name={"min_points"}
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>{t("nollning.missions.min_points")}</FormLabel>
-											<FormControl>
-												<Input
-													type="number"
-													placeholder="0"
-													value={
-														typeof field.value === "number" &&
-														!Number.isNaN(field.value)
-															? field.value
-															: ""
-													}
-													onChange={(e) =>
-														field.onChange(e.target.valueAsNumber)
-													}
-												/>
-											</FormControl>
-										</FormItem>
-									)}
-								/>
-								<FormField
-									control={adventureMissionForm.control}
-									name={"max_points"}
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>{t("nollning.missions.max_points")}</FormLabel>
-											<FormControl>
-												<Input
-													type="number"
-													placeholder="1"
-													value={
-														typeof field.value === "number" &&
-														!Number.isNaN(field.value)
-															? field.value
-															: ""
-													}
-													onChange={(e) =>
-														field.onChange(e.target.valueAsNumber)
-													}
-												/>
-											</FormControl>
-										</FormItem>
-									)}
-								/>
-								<FormField
-									control={adventureMissionForm.control}
-									name={"nollning_week"}
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>{t("nollning.missions.week")}</FormLabel>
-											<FormControl>
-												<Input
-													type="number"
-													placeholder="0"
-													value={
-														typeof field.value === "number" &&
-														!Number.isNaN(field.value)
-															? field.value
-															: ""
-													}
-													onChange={(e) =>
-														field.onChange(e.target.valueAsNumber)
-													}
-												/>
-											</FormControl>
-										</FormItem>
-									)}
-								/>
-							</div>
-							<div className="flex flex-row justify-end space-x-2 mt-4">
-								<Button
-									type="button"
-									variant="outline"
-									onClick={() => setOpen(false)}
-									className="w-32 min-w-fit"
-								>
-									{t("nollning.missions.cancel")}
-								</Button>
-								<Button type="submit" className="w-32 min-w-fit">
-									{t("nollning.missions.create")}
-								</Button>
-							</div>
-						</form>
-					</Form>
-				</DialogContent>
-			</Dialog>
-		</div>
+		<AdminForm
+			title={t("nollning.missions.create_title")}
+			formType="add"
+			gridCols={2}
+			open={open}
+			onOpenChange={setOpen}
+			inputFields={[
+				{
+					variant: "text",
+					name: "title_sv",
+					label: t("nollning.missions.title_sv"),
+					placeholder: t("nollning.missions.title_placeholder"),
+				},
+				{
+					variant: "text",
+					name: "title_en",
+					label: t("nollning.missions.title_en"),
+					placeholder: t("nollning.missions.title_placeholder"),
+				},
+				{
+					variant: "textarea",
+					name: "description_sv",
+					label: t("nollning.missions.description_sv"),
+					placeholder: t("nollning.missions.description_placeholder"),
+				},
+				{
+					variant: "textarea",
+					name: "description_en",
+					label: t("nollning.missions.description_en"),
+					placeholder: t("nollning.missions.description_placeholder"),
+				},
+				{
+					variant: "number",
+					name: "min_points",
+					label: t("nollning.missions.min_points"),
+					placeholder: "0",
+				},
+				{
+					variant: "number",
+					name: "max_points",
+					label: t("nollning.missions.max_points"),
+					placeholder: "1",
+				},
+				{
+					variant: "number",
+					name: "nollning_week",
+					label: t("nollning.missions.week"),
+					placeholder: "0",
+				},
+				{
+					variant: "text",
+					name: "unlock_code",
+					label: t("nollning.missions.unlock_code"),
+					placeholder: t("nollning.missions.unlock_code_placeholder"),
+				},
+				{
+					variant: "text",
+					name: "unlock_hint_sv",
+					label: t("nollning.missions.unlock_hint_sv"),
+					placeholder: t("nollning.missions.unlock_hint_placeholder"),
+				},
+				{
+					variant: "text",
+					name: "unlock_hint_en",
+					label: t("nollning.missions.unlock_hint_en"),
+					placeholder: t("nollning.missions.unlock_hint_placeholder"),
+				},
+			]}
+			zodSchema={AdventureMissionSchema}
+			onSubmit={onSubmit}
+			showDialogButton
+			dialogButtonText={t("nollning.missions.create_button")}
+			defaultValues={{
+				title_sv: "",
+				title_en: "",
+				description_sv: "",
+				description_en: "",
+				max_points: 1,
+				min_points: 0,
+				nollning_week: 0,
+				unlock_code: "",
+				unlock_hint_sv: "",
+				unlock_hint_en: "",
+			}}
+		/>
 	);
 };
 

--- a/src/app/admin/nollning/admin-nollning/adventure-missions/editAdventureMission.tsx
+++ b/src/app/admin/nollning/admin-nollning/adventure-missions/editAdventureMission.tsx
@@ -5,30 +5,11 @@ import {
 	getNollningByYearQueryKey,
 	getNollningQueryKey,
 } from "@/api/@tanstack/react-query.gen";
-import { Button } from "@/components/ui/button";
-import {
-	Dialog,
-	DialogContent,
-	DialogTitle,
-	DialogClose,
-	DialogHeader,
-} from "@/components/ui/dialog";
-import {
-	Form,
-	FormControl,
-	FormField,
-	FormItem,
-	FormLabel,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import React, { useEffect } from "react";
-import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { useState } from "react";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
+import AdminForm from "@/widgets/AdminForm";
 
 const AdventureMissionSchema = z.object({
 	title_sv: z.string().min(2),
@@ -38,42 +19,42 @@ const AdventureMissionSchema = z.object({
 	max_points: z.number().min(1),
 	min_points: z.number().min(0),
 	nollning_week: z.number().min(0).max(4),
+	unlock_code: z.string().optional(),
+	unlock_hint_sv: z.string().optional(),
+	unlock_hint_en: z.string().optional(),
 });
 
 interface Props {
 	open: boolean;
+	setOpen: (open: boolean) => void;
 	onClose: () => void;
 	selectedMission: AdventureMissionRead;
+	setSelectedMission: (mission: AdventureMissionRead | null) => void;
 	nollning_id: number;
 }
 
 const EditAdventureMission = ({
 	open,
+	setOpen,
 	onClose,
 	selectedMission,
+	setSelectedMission,
 	nollning_id,
 }: Props) => {
 	const { t } = useTranslation("admin");
-	const form = useForm<z.infer<typeof AdventureMissionSchema>>({
-		resolver: zodResolver(AdventureMissionSchema),
-		defaultValues: {
-			title_sv: "",
-			title_en: "",
-			description_sv: "",
-			description_en: "",
-			max_points: 1,
-			min_points: 0,
-			nollning_week: 0,
-		},
-	});
 
-	useEffect(() => {
-		if (open && selectedMission) {
-			form.reset({
-				...selectedMission,
-			});
-		}
-	}, [selectedMission, form, open]);
+	const cleanedSelectedMission = {
+		...selectedMission,
+		unlock_code: selectedMission.unlock_code ?? "",
+		unlock_hint_sv: selectedMission.unlock_hint_sv ?? "",
+		unlock_hint_en: selectedMission.unlock_hint_en ?? "",
+	};
+
+	function setConvertedItem(
+		item: z.infer<typeof AdventureMissionSchema> | null,
+	) {
+		setSelectedMission(item ? { ...selectedMission, ...item } : null);
+	}
 
 	const queryClient = useQueryClient();
 
@@ -133,6 +114,9 @@ const EditAdventureMission = ({
 					max_points: values.max_points,
 					min_points: values.min_points,
 					nollning_week: values.nollning_week,
+					unlock_code: values.unlock_code,
+					unlock_hint_sv: values.unlock_hint_sv,
+					unlock_hint_en: values.unlock_hint_en,
 				},
 			},
 			{
@@ -158,188 +142,82 @@ const EditAdventureMission = ({
 	}
 
 	return (
-		<Dialog
+		<AdminForm
+			title={t("nollning.missions.edit_title")}
+			formType="edit"
+			gridCols={2}
 			open={open}
-			onOpenChange={(open) => {
-				if (!open) {
-					onClose();
-				}
-			}}
-		>
-			<DialogContent className="min-w-fit lg:max-w-7xl max-h-[80vh] overflow-y-auto">
-				<DialogHeader>
-					<DialogTitle>{t("nollning.missions.edit_title")}</DialogTitle>
-				</DialogHeader>
-				<Form {...form}>
-					<form
-						onSubmit={form.handleSubmit(onSubmit, (error) =>
-							console.log(error),
-						)}
-						className="w-full"
-					>
-						<div className="px-8 space-x-4 grid grid-cols-1 md:grid-cols-2 gap-4 w-full">
-							<FormField
-								control={form.control}
-								name={"title_sv"}
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>{t("nollning.missions.title_sv")}</FormLabel>
-										<FormControl>
-											<Input
-												placeholder={t("nollning.missions.title_placeholder")}
-												{...field}
-											/>
-										</FormControl>
-									</FormItem>
-								)}
-							/>
-							<FormField
-								control={form.control}
-								name={"title_en"}
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>{t("nollning.missions.title_en")}</FormLabel>
-										<FormControl>
-											<Input
-												placeholder={t("nollning.missions.title_placeholder")}
-												{...field}
-											/>
-										</FormControl>
-									</FormItem>
-								)}
-							/>
-							<FormField
-								control={form.control}
-								name={"description_sv"}
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>
-											{t("nollning.missions.description_sv")}
-										</FormLabel>
-										<FormControl>
-											<textarea
-												className="w-full min-h-[100px] rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-												placeholder={t(
-													"nollning.missions.description_placeholder",
-												)}
-												{...field}
-											/>
-										</FormControl>
-									</FormItem>
-								)}
-							/>
-							<FormField
-								control={form.control}
-								name={"description_en"}
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>
-											{t("nollning.missions.description_en")}
-										</FormLabel>
-										<FormControl>
-											<textarea
-												className="w-full min-h-[100px] rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-												placeholder={t(
-													"nollning.missions.description_placeholder",
-												)}
-												{...field}
-											/>
-										</FormControl>
-									</FormItem>
-								)}
-							/>
-							<FormField
-								control={form.control}
-								name={"min_points"}
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>{t("nollning.missions.min_points")}</FormLabel>
-										<FormControl>
-											<Input
-												type="number"
-												placeholder="0"
-												value={
-													typeof field.value === "number" &&
-													!Number.isNaN(field.value)
-														? field.value
-														: ""
-												}
-												onChange={(e) => field.onChange(e.target.valueAsNumber)}
-											/>
-										</FormControl>
-									</FormItem>
-								)}
-							/>
-							<FormField
-								control={form.control}
-								name={"max_points"}
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>{t("nollning.missions.max_points")}</FormLabel>
-										<FormControl>
-											<Input
-												type="number"
-												placeholder="1"
-												value={
-													typeof field.value === "number" &&
-													!Number.isNaN(field.value)
-														? field.value
-														: ""
-												}
-												onChange={(e) => field.onChange(e.target.valueAsNumber)}
-											/>
-										</FormControl>
-									</FormItem>
-								)}
-							/>
-							<FormField
-								control={form.control}
-								name={"nollning_week"}
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>{t("nollning.missions.week")}</FormLabel>
-										<FormControl>
-											<Input
-												type="number"
-												placeholder="0"
-												value={
-													typeof field.value === "number" &&
-													!Number.isNaN(field.value)
-														? field.value
-														: ""
-												}
-												onChange={(e) => field.onChange(e.target.valueAsNumber)}
-											/>
-										</FormControl>
-									</FormItem>
-								)}
-							/>
-						</div>
-						<div className="flex flex-row justify-end space-x-2 mt-4">
-							<Button
-								type="button"
-								variant="outline"
-								onClick={onClose}
-								className="w-32 min-w-fit"
-							>
-								{t("nollning.missions.cancel")}
-							</Button>
-							<Button type="submit" className="w-32 min-w-fit">
-								{t("nollning.missions.save")}
-							</Button>
-							<Button
-								variant="destructive"
-								type="button"
-								className="w-32 min-w-fit"
-								onClick={onDelete}
-							>
-								{t("nollning.missions.delete")}
-							</Button>
-						</div>
-					</form>
-				</Form>
-			</DialogContent>
-		</Dialog>
+			onOpenChange={setOpen}
+			inputFields={[
+				{
+					variant: "text",
+					name: "title_sv",
+					label: t("nollning.missions.title_sv"),
+					placeholder: t("nollning.missions.title_placeholder"),
+				},
+				{
+					variant: "text",
+					name: "title_en",
+					label: t("nollning.missions.title_en"),
+					placeholder: t("nollning.missions.title_placeholder"),
+				},
+				{
+					variant: "textarea",
+					name: "description_sv",
+					label: t("nollning.missions.description_sv"),
+					placeholder: t("nollning.missions.description_placeholder"),
+				},
+				{
+					variant: "textarea",
+					name: "description_en",
+					label: t("nollning.missions.description_en"),
+					placeholder: t("nollning.missions.description_placeholder"),
+				},
+				{
+					variant: "number",
+					name: "min_points",
+					label: t("nollning.missions.min_points"),
+					placeholder: "0",
+				},
+				{
+					variant: "number",
+					name: "max_points",
+					label: t("nollning.missions.max_points"),
+					placeholder: "1",
+				},
+				{
+					variant: "number",
+					name: "nollning_week",
+					label: t("nollning.missions.week"),
+					placeholder: "0",
+				},
+				{
+					variant: "text",
+					name: "unlock_code",
+					label: t("nollning.missions.unlock_code"),
+					placeholder: t("nollning.missions.unlock_code_placeholder"),
+				},
+				{
+					variant: "text",
+					name: "unlock_hint_sv",
+					label: t("nollning.missions.unlock_hint_sv"),
+					placeholder: t("nollning.missions.unlock_hint_placeholder"),
+				},
+				{
+					variant: "text",
+					name: "unlock_hint_en",
+					label: t("nollning.missions.unlock_hint_en"),
+					placeholder: t("nollning.missions.unlock_hint_placeholder"),
+				},
+			]}
+			zodSchema={AdventureMissionSchema}
+			showDialogButton={false}
+			onSubmit={onSubmit}
+			onDelete={onDelete}
+			useDeleteButton
+			editItem={cleanedSelectedMission}
+			setEditItem={setConvertedItem}
+		/>
 	);
 };
 

--- a/src/app/admin/nollning/admin-nollning/adventure-missions/page.tsx
+++ b/src/app/admin/nollning/admin-nollning/adventure-missions/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import React, { Suspense, useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import idAsNumber from "../idAsNumber";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import {
@@ -15,7 +15,7 @@ import AdminTable from "@/widgets/AdminTable";
 import CreateAdventureMission from "./createAdventureMission";
 import EditAdventureMission from "./editAdventureMission";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Lock } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 import WeekFilter from "@/components/WeekFilter";
@@ -97,7 +97,14 @@ export default function AdventureMissionsPage() {
 	const columns = [
 		columnHelper.accessor(i18n.language === "en" ? "title_en" : "title_sv", {
 			header: t("nollning.missions.title_header"),
-			cell: (info) => info.getValue(),
+			cell: (info) => (
+				<div className="flex items-center gap-1">
+					{info.row.original.unlock_code && (
+						<Lock className="w-4 h-4 shrink-0" />
+					)}
+					{info.getValue()}
+				</div>
+			),
 		}),
 		columnHelper.accessor(
 			i18n.language === "en" ? "description_en" : "description_sv",
@@ -178,8 +185,10 @@ export default function AdventureMissionsPage() {
 				{selectedMission && (
 					<EditAdventureMission
 						open={open}
+						setOpen={setOpen}
 						onClose={onClose}
 						selectedMission={selectedMission}
+						setSelectedMission={setSelectedMission}
 						nollning_id={nollningID}
 					/>
 				)}

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -597,7 +597,12 @@
 			"title_header": "Title",
 			"description_header": "Mission",
 			"points_header": "Allowed Points",
-			"week_header": "Week"
+			"week_header": "Week",
+			"unlock_code": "Unlock code",
+			"unlock_code_placeholder": "If added the code is needed to see mission info. Not cryptographically secure.",
+			"unlock_hint_sv": "Unlock hint (Swedish)",
+			"unlock_hint_en": "Unlock hint (English)",
+			"unlock_hint_placeholder": "The code may be found by solving this riddle: ..."
 		},
 		"mission_grading": {
 			"header_title": "Title",

--- a/src/locales/sv/admin.json
+++ b/src/locales/sv/admin.json
@@ -597,7 +597,12 @@
 			"title_header": "Titel",
 			"description_header": "Uppdrag",
 			"points_header": "Tillåtna poäng",
-			"week_header": "Vecka"
+			"week_header": "Vecka",
+			"unlock_code": "Upplåsningskod",
+			"unlock_code_placeholder": "Om tillagd krävs koden för att se uppdragsinfo. Ej kryptografiskt säker.",
+			"unlock_hint_sv": "Upplåsningshint (Svenska)",
+			"unlock_hint_en": "Upplåsningshint (Engelska)",
+			"unlock_hint_placeholder": "Koden som krävs kan hittas genom att lösa denna gåta: ..."
 		},
 		"mission_grading": {
 			"header_title": "Titel",

--- a/src/widgets/AdminForm.tsx
+++ b/src/widgets/AdminForm.tsx
@@ -57,12 +57,18 @@ type SelectFromOptionsAdminFormInputField<T extends FieldValues> =
 		placeholder?: string;
 	};
 
+type NumberAdminFormInputField<T extends FieldValues> =
+	BaseAdminFormInputField<T> & {
+		variant: "number";
+		placeholder?: string;
+	};
 // Implement further cases here
 
 export type AdminFormInputField<T extends FieldValues> =
 	| TextAdminFormInputField<T>
 	| TextareaAdminFormInputField<T>
-	| SelectFromOptionsAdminFormInputField<T>;
+	| SelectFromOptionsAdminFormInputField<T>
+	| NumberAdminFormInputField<T>;
 
 export interface AdminFormProps<T extends FieldValues> {
 	title: string;
@@ -78,6 +84,7 @@ export interface AdminFormProps<T extends FieldValues> {
 	onDelete?: (data: T) => void;
 	customButtons?: React.ReactNode;
 	showDialogButton?: boolean;
+	dialogButtonText?: string;
 	editItem?: T | null;
 	setEditItem?: (item: T | null) => void;
 	open?: boolean;
@@ -103,6 +110,7 @@ export default function AdminForm<T extends FieldValues>({
 	onDelete,
 	customButtons,
 	showDialogButton = true,
+	dialogButtonText,
 	editItem,
 	setEditItem,
 	open: controlledOpen,
@@ -188,7 +196,7 @@ export default function AdminForm<T extends FieldValues>({
 					}}
 				>
 					{formType === "add" ? <Plus /> : formType === "edit" ? <Pen /> : null}
-					{title}
+					{dialogButtonText || title}
 				</Button>
 			)}
 
@@ -271,6 +279,38 @@ export default function AdminForm<T extends FieldValues>({
 																options={inputField.options}
 																{...field}
 																value={(field.value ?? "") as string}
+															/>
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+										);
+									case "number":
+										return (
+											<FormField
+												key={inputField.name}
+												control={genericForm.control}
+												name={inputField.name}
+												render={({ field }) => (
+													<FormItem
+														className={getColSpanClass(inputField.colSpan)}
+													>
+														<FormLabel>{inputField.label}</FormLabel>
+														<FormControl>
+															<Input
+																type="number"
+																placeholder={inputField.placeholder}
+																{...field}
+																value={
+																	typeof field.value === "number" &&
+																	!Number.isNaN(field.value)
+																		? field.value
+																		: ""
+																}
+																onChange={(e) =>
+																	field.onChange(e.target.valueAsNumber)
+																}
 															/>
 														</FormControl>
 														<FormMessage />


### PR DESCRIPTION
- Admin system for adventure missions now support editing the unlock_code and hints.
- Updated adventure mission admin page to the new AdminForm standard.
- Requires backend changes (https://github.com/fsek/WebWebWeb/pull/550) to function