### PR TITLE
Fix member edit submit button not working

### DIFF
--- a/src/app/admin/members/MemberEditForm.tsx
+++ b/src/app/admin/members/MemberEditForm.tsx
@@ -401,7 +401,7 @@ export default function UserPostsEditForm({
 								>
 									{t("cancel")}
 								</Button>
-								<Button onClick={() => form.handleSubmit(onSubmit)}>
+								<Button onClick={form.handleSubmit(onSubmit)}>
 									<Save />
 									{t("save")}
 								</Button>


### PR DESCRIPTION
Submit button on member edit form was not working due to incorrect usage of arrow function.